### PR TITLE
Fix sz_table length checks

### DIFF
--- a/src/terra/vmap.cpp
+++ b/src/terra/vmap.cpp
@@ -892,8 +892,8 @@ void vrtMap::load(const char* name,int nWorld)
 		for(uint i = 0;i < V_SIZE;i++) {
 			fmap > st_table[i];
 			fmap > sz_table[i];
-//			if(sz_table[i] >= H2_SIZE)
-//				ErrH.Abort("Wrong compression");
+			if(sz_table[i] > H2_SIZE)
+				ErrH.Abort("Wrong compression");
 		}
 		InitSplay(fmap);
 	}
@@ -1024,7 +1024,7 @@ void vrtMap::reload(int nWorld)
 		for(i = 0;i < (int)V_SIZE;i++){
 			fmap > st_table[i];
 			fmap > sz_table[i];
-			if(sz_table[i] >= H2_SIZE)
+			if(sz_table[i] > H2_SIZE)
 				ErrH.Abort("Wrong compression");
 			}
 		InitSplay(fmap);


### PR DESCRIPTION
I believe the intention here is to check if the data would fit into `inbuf` when decompressing. And since it has the size `H2_SIZE`, having the `sz_table[i] == H2_SIZE` should still be legal. This could useful for rudimentary-compressed levels (exported by `vange-rs`).