### PR TITLE
return 0; in sdlEventToCode by default

### DIFF
--- a/src/actint/ascr_fnc.cpp
+++ b/src/actint/ascr_fnc.cpp
@@ -7158,5 +7158,6 @@ int sdlEventToCode(SDL_Event *event) {
 			else
 				return iMOUSE_MOVE_CODE;
 	}
+	return event->type;
 }
 


### PR DESCRIPTION
Hi. Thanks for such amazing project! This is one of my favorite game.

I built master branch for Ubuntu 19.10 + sdl 2. But I have issue with key events. I started game and go to road. Then I press `j`, and Vangers crashes because `sdlEventToCode` does not return (SIGIL). To fix this, I added `return 0;` 
But in that case `j` doing something wrong. It opens inventory, but instead of closing it on second time I saw corrupted screen:
![1](https://user-images.githubusercontent.com/1727152/78523815-3d2c5180-77fc-11ea-88d9-5ac79d88af30.png)


I don't know why `TEXTINPUT` is not handled there it seems should be. I used `ACTINT` enabled, but not sure what it means. 