### PR TITLE
Draw level over entire screen

### DIFF
--- a/lib/xgraph/xgraph.h
+++ b/lib/xgraph/xgraph.h
@@ -109,7 +109,7 @@ struct XGR_Screen
 	unsigned char* ScreenBuf;
 
 	SDL_Surface *XGR_ScreenSurface;
-	//SDL_Surface *XGR_ScreenSurface2D;
+	SDL_Surface *XGR_ScreenSurface2D;
 	SDL_Surface *XGR32_ScreenSurface;
 	//SDL_Surface *XGR32_ScreenSurface2D;
 	SDL_Surface *HDBackgroundSurface;
@@ -193,6 +193,7 @@ struct XGR_Screen
 private:
 	void create_surfaces(int width, int height);
 	void destroy_surfaces();
+	SDL_Surface* currentSurface;
 };
 
 // XGR_MousePromptData::flags...

--- a/src/actint/actint.cpp
+++ b/src/actint/actint.cpp
@@ -3981,6 +3981,8 @@ void actIntDispatcher::init(void)
 	while(ibs){
 		for(int i = 0; i < ibs -> backObjIDs.size(); i++) {
 			ibs -> backs.push_back(get_back_bml(ibs -> backObjIDs[i]));
+			ibs -> backs[i] -> load(NULL, 1);
+			layout(ibs -> backs[i], XGR_MAXX, XGR_MAXY);
 		}
 		ibs = (ibsObject*)ibs -> prev;
 	}

--- a/src/actint/actint.cpp
+++ b/src/actint/actint.cpp
@@ -5242,14 +5242,14 @@ void actIntDispatcher::EventQuant(void)
 			case EV_FULLSCR_CHANGE:
 				flags ^= AS_FULLSCR;
 				if(flags & AS_FULLSCR){
-					set_screen(XGR_MAXX/2 - 0,XGR_MAXY/2 - 0,0,XGR_MAXX/2,XGR_MAXY/2);
+					set_screen(XGR_MAXX/2, XGR_MAXY/2,0, XGR_MAXX/2, XGR_MAXY/2);
 					XGR_MouseHide();
 					XGR_MouseSetPromptData(NULL);
 				}
 				else {
 					flags &= ~AS_FULL_REDRAW;
 					flags &= ~AS_TEXT_MODE;
-					set_screen(curIbs -> SideX,curIbs -> SideY,0,curIbs -> CenterX,curIbs -> CenterY);
+					set_screen(XGR_MAXX/2, XGR_MAXY/2,0, XGR_MAXX/2, XGR_MAXY/2);
 					XGR_MouseShow();
 					if(curMode == AS_INV_MODE){
 						XGR_MouseSetPromptData(invPrompt);
@@ -5407,7 +5407,7 @@ void actIntDispatcher::EventQuant(void)
 				if(flags & AS_FULLSCR){
 					flags &= ~AS_FULL_REDRAW;
 					flags &= ~AS_FULLSCR;
-					set_screen(curIbs -> SideX,curIbs -> SideY,0,curIbs -> CenterX,curIbs -> CenterY);
+					set_screen(XGR_MAXX/2, XGR_MAXY/2, 0, XGR_MAXX/2, XGR_MAXY/2);
 					XGR_MouseShow();
 					if(curMode == AS_INV_MODE)
 						XGR_MouseSetPromptData(invPrompt);
@@ -5421,7 +5421,7 @@ void actIntDispatcher::EventQuant(void)
 				if(!(flags & AS_FULLSCR)){
 					flags |= AS_FULLSCR;
 					flags &= ~AS_TEXT_MODE;
-					set_screen(XGR_MAXX/2 - 0,XGR_MAXY/2 - 0,0,XGR_MAXX/2,XGR_MAXY/2);
+					set_screen(XGR_MAXX/2, XGR_MAXY/2, 0, XGR_MAXX/2, XGR_MAXY/2);
 					XGR_MouseHide();
 					XGR_MouseSetPromptData(NULL);
 				}
@@ -5431,7 +5431,7 @@ void actIntDispatcher::EventQuant(void)
 				if(flags & AS_FULLSCR){
 					flags &= ~AS_FULL_REDRAW;
 					flags &= ~AS_FULLSCR;
-					set_screen(curIbs -> SideX,curIbs -> SideY,0,curIbs -> CenterX,curIbs -> CenterY);
+					set_screen(XGR_MAXX/2, XGR_MAXY/2, 0, XGR_MAXX/2, XGR_MAXY/2);
 					if(curMode == AS_INV_MODE)
 						XGR_MouseSetPromptData(invPrompt);
 					if(curMode == AS_INFO_MODE)
@@ -5471,7 +5471,7 @@ void actIntDispatcher::EventQuant(void)
 				if(flags & AS_FULLSCR){
 					flags &= ~AS_FULL_REDRAW;
 					flags &= ~AS_FULLSCR;
-					set_screen(curIbs -> SideX,curIbs -> SideY,0,curIbs -> CenterX,curIbs -> CenterY);
+					set_screen(XGR_MAXX/2, XGR_MAXY/2, 0, XGR_MAXX/2, XGR_MAXY/2);
 					XGR_MouseShow();
 					if(curMode == AS_INV_MODE)
 						XGR_MouseSetPromptData(invPrompt);

--- a/src/actint/actint.cpp
+++ b/src/actint/actint.cpp
@@ -3294,8 +3294,6 @@ void actIntDispatcher::redraw(void)
 		XGR_MouseObj.flags &= ~XGM_PROMPT_ACTIVE;
 		XGR_Obj.fill(0);
 		for(int i = 0; i < curIbs -> backs.size(); i++) {
-			curIbs -> backs[i] -> load(NULL, 1);
-			layout(curIbs -> backs[i], XGR_MAXX, XGR_MAXY);
 			curIbs -> backs[i] -> show(0);
 		}
 		if(curMode == AS_INV_MODE && curMatrix && curMatrix -> back){
@@ -3448,6 +3446,39 @@ void actIntDispatcher::redraw(void)
 	}
 }
 
+void actIntDispatcher::text_redraw(){
+	if(Pause > 1 && NetworkON){
+		if(GameQuantReturnValue || acsQuant()){
+			Pause = 0;
+		}
+		flags |= AS_FULL_FLUSH;
+	}
+
+	if(flags & AS_TEXT_MODE){
+		ScrTextData -> redraw();
+		ScrTextData -> Quant();
+	}
+	if(curPrompt -> NumStr){
+		curPrompt -> redraw(0,0,XGR_MAXX,XGR_MAXY);
+		curPrompt -> quant();
+	}
+	if(flags & AS_CHAT_MODE){
+		iChatQuant();
+	}
+	else {
+		if(aciRacingFlag){
+			aciShowRacingPlace();
+		}
+	}
+	if(Pause > 1 && NetworkON){
+		if(GameQuantReturnValue || acsQuant()){
+			Pause = 0;
+		}
+	}
+
+
+}
+
 void actIntDispatcher::i_redraw(void)
 {
 	fncMenu* p;
@@ -3595,34 +3626,9 @@ void actIntDispatcher::flush(void)
 			PalIterLock = 0;
 			flags ^= AS_EVINCE_PALETTE;
 		}
-		if(flags & AS_TEXT_MODE){
-			ScrTextData -> redraw();
-			ScrTextData -> Quant();
-		}
-		if(curPrompt -> NumStr){
-			curPrompt -> redraw(0,0,XGR_MAXX,XGR_MAXY);
-			curPrompt -> quant();
-		}
-		if(flags & AS_CHAT_MODE){
-			iChatQuant();
-		}
-		else {
-			if(aciRacingFlag){
-				aciShowRacingPlace();
-			}
-		}
-		if(Pause > 1 && NetworkON){
-			if(GameQuantReturnValue || acsQuant()){
-				Pause = 0;
-			}
-		}
 		return;
 	}
-	if(curPrompt -> NumStr){
-		curPrompt -> redraw(curIbs -> PosX,curIbs -> PosY,curIbs -> SizeX,curIbs -> SizeY);
-		curPrompt -> quant();
-	}
-	curIbs -> show();
+
 	ind = (aIndData*)indList -> last;
 	while(ind){
 		ind -> redraw();
@@ -3630,16 +3636,6 @@ void actIntDispatcher::flush(void)
 		ind = (aIndData*)ind -> prev;
 	}
 
-	if(aciRacingFlag){
-		aciShowRacingPlace();
-	}
-
-	if(Pause > 1 && NetworkON){
-		if(GameQuantReturnValue || acsQuant()){
-			Pause = 0;
-		}
-		flags |= AS_FULL_FLUSH;
-	}
 
 	if(flags & AS_FULL_FLUSH){
 		flags &= ~AS_FULL_FLUSH;

--- a/src/actint/actint.h
+++ b/src/actint/actint.h
@@ -1383,6 +1383,7 @@ struct actIntDispatcher
 
 	void redraw(void);
 	void ind_redraw(void);
+	void text_redraw();
 	void flush(void);
 	void pal_flush();
 

--- a/src/actint/ascr_fnc.cpp
+++ b/src/actint/ascr_fnc.cpp
@@ -1556,7 +1556,7 @@ void change_screen(int mode)
 {
 	aScrDisp -> change_ibs(mode);
 	aScrDisp -> flags &= ~AS_FULL_REDRAW;
-	set_screen(aScrDisp -> curIbs -> SideX,aScrDisp -> curIbs -> SideY,0,aScrDisp -> curIbs -> CenterX,aScrDisp -> curIbs -> CenterY);
+	set_screen(XGR_MAXX/2, XGR_MAXY/2, 0, XGR_MAXX/2, XGR_MAXY/2);
 }
 
 void aciSendEvent2actint(int code,actintItemData* p,int data)

--- a/src/actint/ascr_fnc.cpp
+++ b/src/actint/ascr_fnc.cpp
@@ -689,8 +689,6 @@ void actIntQuant(void)
 	actintActiveFlag = 1;
 	aScrDisp -> KeyQuant();
 	aScrDisp -> EventQuant();
-	/*Нужно что бы не было мерцания когда подгружаются полноэкранные картинки прям в видео буфер.*/
-	aScrDisp -> redraw(); 
 }
 
 void aLoadFonts(void)

--- a/src/road.cpp
+++ b/src/road.cpp
@@ -2054,14 +2054,15 @@ void iGameMap::draw(int self)
 		FirstDraw = 0;
 //2D Rendring in game.
 #ifdef ACTINT
-		//XGR_Obj.set_render_buffer(XGR_Obj.XGR_ScreenSurface2D);
+		XGR_Obj.set_render_buffer(XGR_Obj.XGR_ScreenSurface2D);
 		//XGR_Obj.fill(2);
 		if(GeneralSystemSkip) {
 			aScrDisp -> redraw();
 		}
 		aScrDisp -> flush();
 		//aScrDisp->pal_flush();
-		//XGR_Obj.set_render_buffer(XGR_Obj.XGR_ScreenSurface);
+		XGR_Obj.set_render_buffer(XGR_Obj.XGR_ScreenSurface);
+		aScrDisp -> text_redraw();
 #endif
 	};
 	

--- a/src/road.cpp
+++ b/src/road.cpp
@@ -798,8 +798,8 @@ void LoadingRTO1::Init(int id)
 #endif
 
 #ifdef ACTINT
-	XSIDE = aScrDisp -> curIbs -> SideX;
-	YSIDE = aScrDisp -> curIbs -> SideY;
+	XSIDE = XGR_MAXX / 2;
+	YSIDE = XGR_MAXY / 2;
 	XSIZE = 2*XSIDE;
 	YSIZE = 2*YSIDE;
 #else
@@ -968,7 +968,7 @@ _MEM_STATISTIC_("AFTER TABLE GENERAL  -> ");
 _MEM_STATISTIC_("AFTER TABLE OPEN  -> ");
 
 #ifdef ACTINT
-	curGMap = new iGameMap(aScrDisp -> curIbs -> CenterX,aScrDisp -> curIbs -> CenterY,XSIDE,YSIDE);
+	curGMap = new iGameMap(XGR_MAXX / 2, XGR_MAXY / 2, XGR_MAXX / 2, XGR_MAXY / 2);
 #else
 	curGMap = new iGameMap(XGR_MAXX/2,XGR_MAXY/2,XSIDE,YSIDE);
 #endif


### PR DESCRIPTION
This pull request shows level map over entire screen and always redraws GUI elements.

* 171c277 - moved initialization code for ibs backgrounds
* bd37991 - Showing level with XGR_MAXX, XGR_MAXY width as in full screen mode
* 07e189a - XGR_Screen added XGR_ScreenSurface2D for 2D rendering. Modified XGR_Screen::flip method
* 14640a1 - Switching to XGR_ScreenSurface2D on in-game-GUI rendering. Small refactoring. SDL_UnlockSurface fixes