### PR TITLE
Disabled binary script in GitHub Actions  

### DIFF
--- a/.github/workflows/vangers_linux_build.yml
+++ b/.github/workflows/vangers_linux_build.yml
@@ -19,7 +19,7 @@ jobs:
       run: git clone --depth 1 https://github.com/stalkerg/clunk.git clunk
       working-directory: /tmp
     - name: clunk build and install
-      run: cmake -DCMAKE_INSTALL_PREFIX=/usr . && make && sudo make install
+      run: cmake -DCMAKE_INSTALL_PREFIX=/usr -DBINARY_SCRIPT=OFF. && make && sudo make install
       working-directory: /tmp/clunk
     - name: configure
       run: mkdir build && cd build && cmake ..

--- a/.github/workflows/vangers_macos_build.yml
+++ b/.github/workflows/vangers_macos_build.yml
@@ -58,7 +58,7 @@ jobs:
       env:
         MACOSX_DEPLOYMENT_TARGET: 10.12
     - name: configure
-      run: mkdir build && cd build && cmake -G Ninja ..
+      run: mkdir build && cd build && cmake -G Ninja -DBINARY_SCRIPT=OFF ..
       env:
         MACOSX_DEPLOYMENT_TARGET: 10.12
     - name: make

--- a/.github/workflows/vangers_windows_32_build.yml
+++ b/.github/workflows/vangers_windows_32_build.yml
@@ -60,7 +60,7 @@ jobs:
     - name: vangers -- create build dir
       run: msys2do mkdir build
     - name: vangers -- configure
-      run: msys2do cmake -G Ninja ..
+      run: msys2do cmake -G Ninja -DBINARY_SCRIPT=OFF ..
       working-directory: build
     - name: vangers -- make
       run: msys2do ninja

--- a/.github/workflows/vangers_windows_64_build.yml
+++ b/.github/workflows/vangers_windows_64_build.yml
@@ -60,7 +60,7 @@ jobs:
     - name: vangers -- create build dir
       run: msys2do mkdir build
     - name: vangers -- configure
-      run: msys2do cmake -G Ninja ..
+      run: msys2do cmake -G Ninja -DBINARY_SCRIPT=OFF ..
       working-directory: build
     - name: vangers -- make
       run: msys2do ninja


### PR DESCRIPTION
Disabled `BINARY_SCRIPT` define in GitHub Actions  in order to make Vangers read updated resource files from data folder