### PR TITLE
SDL_Surface lock/unlock fixes

### DIFF
--- a/lib/xgraph/xgraph.cpp
+++ b/lib/xgraph/xgraph.cpp
@@ -251,6 +251,14 @@ void XGR_Screen::create_surfaces(int width, int height) {
 	set_render_buffer(XGR_ScreenSurface);
 }
 
+void XGR_Screen::lock_current_surface() {
+	assert(SDL_LockSurface(currentSurface) == 0);
+}
+
+void XGR_Screen::unlock_current_surface() {
+	SDL_UnlockSurface(currentSurface);
+}
+
 void XGR_Screen::set_resolution(int width, int height){
 	// TODO: do not change resolution, is new res is the same
 	std::cout<<"XGR_Screen::set_resolution: "<<width<<", "<<height<<std::endl;

--- a/lib/xgraph/xgraph.cpp
+++ b/lib/xgraph/xgraph.cpp
@@ -239,11 +239,6 @@ void XGR_Screen::create_surfaces(int width, int height) {
 		SDL_SetWindowPosition(sdlWindow, 0, 0);
 	}
 
-	// TODO(amdmi3): assuming safe locking; otherwise, use additional surface + SDL_MapRGB
-	std::cout<<"SDL_LockSurface"<<std::endl;
-	if (SDL_LockSurface(XGR_ScreenSurface) < 0)
-		ErrH.Abort(SDL_GetError(),XERR_USER, 0);
-
 	// Other initializations
 	ScreenX = xgrScreenSizeX = XGR_ScreenSurface->w;
 	ScreenY = xgrScreenSizeY = XGR_ScreenSurface->h;

--- a/lib/xgraph/xgraph.h
+++ b/lib/xgraph/xgraph.h
@@ -187,6 +187,8 @@ struct XGR_Screen
 	void blitScreen(uint32_t *dst, uint8_t *src);
 
 	void set_render_buffer(SDL_Surface *buf);
+	void lock_current_surface();
+	void unlock_current_surface();
 	
 	XGR_Screen(void);
 

--- a/src/iscreen/iextern.cpp
+++ b/src/iscreen/iextern.cpp
@@ -661,7 +661,9 @@ void iSetResolution(int state) {
 			break;
 
 	}
+	XGR_Obj.lock_current_surface();
 	put_map(iScreenOffs,0,I_RES_X,I_RES_Y);
+	XGR_Obj.unlock_current_surface();
 }
 
 void iPrepareOptions(void)


### PR DESCRIPTION
* Removed unnecessary `SDL_LockSurface` on surface creation 
* XGR_Screen public functions for locking/unlocking current surface 
* Wrapping iscreen `put_map` with lock/unlock surface calls in `iSetResolution`