### PR TITLE
Fixed item drop mechanics

### DIFF
--- a/src/actint/actint.cpp
+++ b/src/actint/actint.cpp
@@ -7392,11 +7392,11 @@ void actIntDispatcher::inv_mouse_move_quant(void)
 	x = iMouseX;
 	y = iMouseY;
 
-	ix = curIbs -> PosX;
-	iy = curIbs -> PosY;
+	ix = 0;
+	iy = 0;
 
-	isx = ix + curIbs -> SizeX;
-	isy = iy + curIbs -> SizeY;
+	isx = ix + XGR_MAXX;
+	isy = iy + XGR_MAXY;
 
 	if(x >= ix && x < isx && y >= iy && y < isy){
 		id = aciGetScreenItem(x,y);

--- a/src/units/items.cpp
+++ b/src/units/items.cpp
@@ -1991,8 +1991,7 @@ int aciGetScreenItem(int x,int y)
 	mp = NULL;
 	rz = -1;
 	S2G(x,y,tx,ty);
-
-	GeneralMousePoint = Vector(getDistX(tx,ViewX),getDistY(ty,ViewY),0);
+	GeneralMousePoint = Vector(getDistX(tx, ActD.Active->R_curr.x), getDistY(ty, ActD.Active->R_curr.y), 0);
 
 	p = (BaseObject*)(ItemD.Tail);
 	while(p){


### PR DESCRIPTION
Fixed item drop direction: 
* Mouse coordinates calculated now with respect to full screen boundaries instead of obsolete GUI frame boundaries.
* Calculating drop center from ViewX/ViewY instead of player coordinates. 

closes #312 