### PR TITLE
Fixed compass behavior

### DIFF
--- a/src/units/hobj.cpp
+++ b/src/units/hobj.cpp
@@ -2781,6 +2781,23 @@ int G2LF(int x,int y,int z,int& sx,int& sy)
 	return round(256.*z1);
 };
 
+void global_to_screen(int x, int y, int z, int &sx, int &sy)
+{
+	// The code is from Object::update_coord
+
+	int xx = getDistX(x, ViewX);
+	int yy = getDistY(y ,ViewY);
+
+	double x1 = A_g2s.a[0]*xx + A_g2s.a[1]*yy - A_g2s.a[2]*z;
+	double y1 = A_g2s.a[3]*xx + A_g2s.a[4]*yy - A_g2s.a[5]*z;
+	double z0 = A_g2s.a[6]*xx + A_g2s.a[7]*yy;
+	double z1 = z0 + ViewZ;
+
+	z1 = z1 > 0 ? focus_flt / z1 : 1;
+	sx = round(x1 * z1) + ScreenCX;
+	sy = round(y1 * z1) + ScreenCY;
+};
+
 void S2G(int xs,int ys,int& xg,int& yg)
 {
 	xs -= ScreenCX;

--- a/src/units/hobj.h
+++ b/src/units/hobj.h
@@ -198,6 +198,7 @@ int G2LF(int x,int y,int z,int& sx,int& sy);
 void G2LQ(int x,int y,int z,int& sx,int& sy);
 void G2LP(int x,int y,int z,int& sx,int& sy);
 void S2G(int xs,int ys,int& xg,int& yg);
+void global_to_screen(int x, int y, int z, int &sx, int &sy);
 
 //void SetMapBuff(int x,int y,int x_size,int y_size,uchar* MapBuf);
 

--- a/src/units/mechos.cpp
+++ b/src/units/mechos.cpp
@@ -8641,16 +8641,15 @@ void CompasObject::Quant(void)
 	v = Vector(ActD.Active->Speed,0,0)*ActD.Active->RotMat;
 	x = XCYCL(x + vMove.x + v.x);
 	y = YCYCL(y + vMove.y + v.y);
-	if(AdvancedView) G2LQ(x,y,0,tx,ty);
-	else G2LS(x,y,0,tx,ty);
 
+	global_to_screen(x, y, 0, tx, ty);
 	if(tx < UcutLeft + COMPAS_LEFT){
 		tx = UcutLeft + COMPAS_LEFT;
 		vMove.x = 0;
 	};
 
-	if(tx > UcutRight - COMPAS_RIGHT){
-		tx = UcutRight - COMPAS_RIGHT;
+	if(tx > UcutRight - COMPAS_RIGHT - mechosCameraOffsetX * 2){
+		tx = UcutRight - COMPAS_RIGHT - mechosCameraOffsetX * 2;
 		vMove.x = 0;
 	};
 


### PR DESCRIPTION
* Compass offset is calculated according to `mechosCameraOffset` varaible (basically right GUI size).
* Fixed compass behavior in slope/turn mode. New `global_to_screen` function which correctly calculates screen coordinates from world ones. The code is taken from `Object::update_coord`. The similar `G2LQ` function works improperly.

Closes #309 