### PR TITLE
Fixed oxygen offset

### DIFF
--- a/src/units/mechos.cpp
+++ b/src/units/mechos.cpp
@@ -8173,7 +8173,7 @@ void ActionDispatcher::DrawResource(void)
 	XGR_SetClip(UcutLeft,VcutUp,UcutRight,VcutDown);
 
 	y0 = VcutDown - RES_DRAW_DOWN;
-	x0 = UcutRight - RES_DRAW_LEFT;
+	x0 = UcutRight - RES_DRAW_LEFT - mechosCameraOffsetX;
 	x1 = UcutLeft + RES_DRAW_LEFT;
 	sx = x0 - x1;
 

--- a/src/units/mechos.h
+++ b/src/units/mechos.h
@@ -943,7 +943,7 @@ struct CompasObject
 //const int SPEETLE_AMMO = 0;
 //const int CRUSTEST_AMMO = 1;
 
-const int RES_DRAW_LEFT = 50;
+const int RES_DRAW_LEFT = 150;
 const int RES_DRAW_DOWN = 80;
 const int RES_DRAW_STEP_Y = 10;
 const int RES_DRAW_MAX_SIZE = 300;


### PR DESCRIPTION
Moved oxygen bar according to `mechosCameraOffsetX` variable.

Closes #310