### PR TITLE
disabled unpress key handler in the main game menu

### DIFF
--- a/src/iscreen/ikeys.cpp
+++ b/src/iscreen/ikeys.cpp
@@ -22,7 +22,7 @@ void KBD_init(void) {
 	if(!KeyBuf)
 		KeyBuf = new KeyBuffer;
 
-	set_key_nadlers(&key, &unpress_key);
+	set_key_nadlers(&key, NULL);
 }
 
 void key(SDL_Event *key) {


### PR DESCRIPTION
отключен обработчки отжатия клавиши в меню игры,  
который вызывал повторное срабатывание  клавиши ESC,
ESC-> выход в меню -> ESC -> выход из игры
Предыстория игры ESC #290
#290 (comment)