### PR TITLE
Fix iss330 disable right menu, when teleporting 

### DIFF
--- a/src/actint/actint.cpp
+++ b/src/actint/actint.cpp
@@ -5347,7 +5347,7 @@ void actIntDispatcher::EventQuant(void)
 				lock();
 				break;
 			case ACI_UNLOCK_INTERFACE:
-				if(flags & AS_FULLSCR){
+				if(flags & AS_FULLSCR){ 
 					flags &= ~AS_FULL_REDRAW;
 					flags &= ~AS_FULLSCR;
 					set_screen(curIbs -> SideX,curIbs -> SideY,0,curIbs -> CenterX,curIbs -> CenterY);
@@ -5357,7 +5357,7 @@ void actIntDispatcher::EventQuant(void)
 						XGR_MouseSetPromptData(infPrompt);
 					XGR_MouseShow();
 				}
-				unlock();
+				unlock(); // logical, functional blocking
 				break;
 			case EV_PROTRACTOR_EVENT:
 				aciProtractorEvent = p -> data;

--- a/src/units/mechos.cpp
+++ b/src/units/mechos.cpp
@@ -5601,16 +5601,16 @@ void VangerUnit::SensorQuant(void)
 				GameQuantReturnValue = RTO_LOADING3_ID;
 			};
 			break;
-		case EXTERNAL_MODE_IN_VANGER:
+		case EXTERNAL_MODE_IN_VANGER:  // teleport from mehos 
 			ExternalTime--;
-			aciSendEvent2actint(ACI_LOCK_INTERFACE,NULL);
+			aciSendEvent2actint(ACI_LOCK_INTERFACE,NULL); // disable right menu and full screen
 			if(ExternalTime <= 0){
 				SOUND_BOOT_STOP();
 				Go2Universe();
 				Status |= SOBJ_DISCONNECT;
 			};			
 			break;
-		case EXTERNAL_MODE_OUT_VANGER:
+		case EXTERNAL_MODE_OUT_VANGER:  // loading into mechos
 			ExternalTime--;
 			if(ExternalTime <= 0){
 				SOUND_BOOT_STOP();
@@ -5619,7 +5619,7 @@ void VangerUnit::SensorQuant(void)
 				ExternalDraw = 1;
 				switch_analysis(0);
 				ExternalSensor = ExternalObject;
-				aciSendEvent2actint(ACI_UNLOCK_INTERFACE,NULL);
+				aciSendEvent2actint(ACI_UNLOCK_INTERFACE,NULL); // enable right menu 
 			};
 			break;
 	};

--- a/src/units/mechos.cpp
+++ b/src/units/mechos.cpp
@@ -5603,6 +5603,7 @@ void VangerUnit::SensorQuant(void)
 			break;
 		case EXTERNAL_MODE_IN_VANGER:
 			ExternalTime--;
+			aciSendEvent2actint(ACI_LOCK_INTERFACE,NULL);
 			if(ExternalTime <= 0){
 				SOUND_BOOT_STOP();
 				Go2Universe();
@@ -5618,6 +5619,7 @@ void VangerUnit::SensorQuant(void)
 				ExternalDraw = 1;
 				switch_analysis(0);
 				ExternalSensor = ExternalObject;
+				aciSendEvent2actint(ACI_UNLOCK_INTERFACE,NULL);
 			};
 			break;
 	};


### PR DESCRIPTION
disable right  menu, when teleporting form the "boot sector". Using the
standard function "aciSendEvent2actint"
added comments

https://github.com/KranX/Vangers/issues/330