### PR TITLE
Fix gcc warnings 'unused-parameter' by changing signature of functions

### DIFF
--- a/src/units/effect.cpp
+++ b/src/units/effect.cpp
@@ -762,7 +762,7 @@ void ParticleObject::DrawQuant(void)
 				p->QuantRingOfLord(Vector(R_curr.x << 8,R_curr.y << 8,R_curr.z << 8),abs(25 * SI[rPI(phi >> 8)] >> 8),32);
 				vPos = p->vR;
 				vPos >>= 8;
-//				if(GetAltLevel(vPos.x,vPos.y,vPos.z)){
+//				if(GetAltLevel(vPos)){
 					G2LQ(vPos,tx,ty);
 	//				G2L(vPos.x,vPos.y,tx,ty);
 					if(tx > UcutLeft && tx < UcutRight && ty > VcutUp && ty < VcutDown) XGR_SetPixelFast(tx,ty,p->Color >> 8);
@@ -775,7 +775,7 @@ void ParticleObject::DrawQuant(void)
 					p->QuantRingOfLord(Vector(R_curr.x << 8,R_curr.y << 8,R_curr.z << 8),abs(25 * SI[rPI(phi >> 8)] >> 8),32);
 					vPos = p->vR;
 					vPos >>= 8;
-	//				if(GetAltLevel(vPos.x,vPos.y,vPos.z)){
+	//				if(GetAltLevel(vPos)){
 		//				tx = round(SPGetDistX(p->vR.x,SPViewX)*ScaleMapInvFlt) + ScreenCX;
 		//				ty = round((p->vR.y - SPViewY) * ScaleMapInvFlt) + ScreenCY;
 
@@ -791,7 +791,7 @@ void ParticleObject::DrawQuant(void)
 					p->QuantRingOfLord(Vector(R_curr.x << 8,R_curr.y << 8,R_curr.z << 8),abs(25 * SI[rPI(phi >> 8)] >> 8),32);
 					vPos = p->vR;
 					vPos >>= 8;
-	//				if(GetAltLevel(vPos.x,vPos.y,vPos.z)){
+	//				if(GetAltLevel(vPos)){
 		//				tx = round(SPGetDistX(p->vR.x,SPViewX)*ScaleMapInvFlt) + ScreenCX;
 		//				ty = round((p->vR.y - SPViewY) * ScaleMapInvFlt) + ScreenCY;
 
@@ -810,7 +810,7 @@ void ParticleObject::DrawQuant(void)
 				p->Quant();
 				vPos = p->vR;
 				vPos >>= 8;
-				if(GetAltLevel(vPos.x,vPos.y,vPos.z)){
+				if(GetAltLevel(vPos)){
 					G2LQ(vPos,tx,ty);
 	//				G2L(vPos.x,vPos.y,tx,ty);
 					if(tx > UcutLeft && tx < UcutRight && ty > VcutUp && ty < VcutDown) XGR_SetPixelFast(tx,ty,p->Color >> 8);
@@ -822,7 +822,7 @@ void ParticleObject::DrawQuant(void)
 					p->Quant();
 					vPos = p->vR;
 					vPos >>= 8;
-					if(GetAltLevel(vPos.x,vPos.y,vPos.z)){
+					if(GetAltLevel(vPos)){
 		//				tx = round(SPGetDistX(p->vR.x,SPViewX)*ScaleMapInvFlt) + ScreenCX;
 		//				ty = round((p->vR.y - SPViewY) * ScaleMapInvFlt) + ScreenCY;
 
@@ -837,7 +837,7 @@ void ParticleObject::DrawQuant(void)
 					p->Quant();
 					vPos = p->vR;
 					vPos >>= 8;
-					if(GetAltLevel(vPos.x,vPos.y,vPos.z)){
+					if(GetAltLevel(vPos)){
 		//				tx = round(SPGetDistX(p->vR.x,SPViewX)*ScaleMapInvFlt) + ScreenCX;
 		//				ty = round((p->vR.y - SPViewY) * ScaleMapInvFlt) + ScreenCY;
 
@@ -852,12 +852,12 @@ void ParticleObject::DrawQuant(void)
 	};
 };
 
-int  GetAltLevel(int x,int y,int z)
+int GetAltLevel(Vector v)
 {
-	uchar* p = vMap->lineT[y];
+	uchar* p = vMap->lineT[v.y];
 	if(p){
-		p += x;
-		if((*(p+1)) < z && (*p) < z  ) return 1;
+		p += v.x;
+		if( (*(p+1)) < v.z && (*p) < v.z ) return 1;
 	};
 	return 0;
 };
@@ -1679,7 +1679,7 @@ void WaterParticleObject::DrawQuant(void)
 					p->QuantT(vCenter.x,vCenter.y,Velocity);
 					vPos = p->vR;
 					vPos >>= 8;
-					if(GetAltLevel(vPos.x,vPos.y,vPos.z)){
+					if(GetAltLevel(vPos)){
 						G2L(vPos,tx,ty);
 						if(tx > UcutLeft && tx < UcutRight && ty > VcutUp && ty < VcutDown) XGR_SetPixelFast(tx,ty,p->Color >> 8);
 					};
@@ -1689,7 +1689,7 @@ void WaterParticleObject::DrawQuant(void)
 					p->QuantT(vCenter.x,vCenter.y,Velocity);
 					vPos = p->vR;
 					vPos >>= 8;
-					if(GetAltLevel(vPos.x,vPos.y,vPos.z)){
+					if(GetAltLevel(vPos)){
 						tx = ((int)round(SPGetDistX(p->vR.x,SPViewX) * ScaleMapInvFlt) >> 8) + ScreenCX;
 						ty = ((int)round((p->vR.y - SPViewY) * ScaleMapInvFlt) >> 8)+ ScreenCY;
 
@@ -1731,7 +1731,7 @@ void WaterParticleObject::DrawQuant(void)
 					p->Quant();
 					vPos = p->vR;
 					vPos >>= 8;
-					if(GetAltLevel(vPos.x,vPos.y,vPos.z)){
+					if(GetAltLevel(vPos)){
 						G2L(vPos,tx,ty);
 						if(tx > UcutLeft && tx < UcutRight && ty > VcutUp && ty < VcutDown) XGR_SetPixelFast(tx,ty,p->Color >> 8);
 					};
@@ -1741,7 +1741,7 @@ void WaterParticleObject::DrawQuant(void)
 					p->Quant();
 					vPos = p->vR;
 					vPos >>= 8;
-					if(GetAltLevel(vPos.x,vPos.y,vPos.z)){
+					if(GetAltLevel(vPos)){
 						tx = ((int)round(SPGetDistX(p->vR.x,SPViewX) * ScaleMapInvFlt) >> 8) + ScreenCX;
 						ty = ((int)round((p->vR.y - SPViewY) * ScaleMapInvFlt) >> 8)+ ScreenCY;
 

--- a/src/units/effect.cpp
+++ b/src/units/effect.cpp
@@ -1994,7 +1994,7 @@ void ParticleGenerator::Quant(void)
 	cycleTor(R_curr.x,R_curr.y);	
 
 	Time--;
-	GetAlt(R_curr.x,R_curr.y,R_curr.z,alt);
+	GetAlt(R_curr,alt);
 	R_curr.z = alt + radius;
 	if(Time <= 0) Status |= SOBJ_DISCONNECT;
 };

--- a/src/units/effect.cpp
+++ b/src/units/effect.cpp
@@ -123,8 +123,8 @@ void ExplosionObject::Free(void)
 void ExplosionObject::DrawQuant(void)
 {
 	int tx,ty,s;
-	if(AdvancedView) s = G2LF(R_curr.x,R_curr.y,R_curr.z,tx,ty);
-	else s = G2LS(R_curr.x,R_curr.y,R_curr.z,tx,ty);
+	if(AdvancedView) s = G2LF(R_curr,tx,ty);
+	else s = G2LS(R_curr,tx,ty);
 	if(MainMapProcess.process((char*)XGR_GetVideoLine(0),tx,ty,Scale*s >> 8,0,0,R_curr.z,R_curr.x & clip_mask_x, R_curr.y & clip_mask_y)) Status |= SOBJ_DISCONNECT;
 
 //	if(MainMapProcess.process((char*)(VS(_video)->_video),tx,ty,Scale*curGMap -> xsize / TurnSecX,0,0)) Status |= SOBJ_DISCONNECT;
@@ -538,7 +538,7 @@ void DeformObject::Quant(void)
 void DeformObject::DrawQuant(void)
 {
 	int tx,ty;
-	G2L(R_curr.x,R_curr.y,tx,ty);
+	G2L(R_curr,tx,ty);
 	wProcess->Deform(tx,ty,Offset,FullFlag);
 };
 
@@ -763,7 +763,7 @@ void ParticleObject::DrawQuant(void)
 				vPos = p->vR;
 				vPos >>= 8;
 //				if(GetAltLevel(vPos.x,vPos.y,vPos.z)){
-					G2LQ(vPos.x,vPos.y,vPos.z,tx,ty);
+					G2LQ(vPos,tx,ty);
 	//				G2L(vPos.x,vPos.y,tx,ty);
 					if(tx > UcutLeft && tx < UcutRight && ty > VcutUp && ty < VcutDown) XGR_SetPixelFast(tx,ty,p->Color >> 8);
 //				};
@@ -811,7 +811,7 @@ void ParticleObject::DrawQuant(void)
 				vPos = p->vR;
 				vPos >>= 8;
 				if(GetAltLevel(vPos.x,vPos.y,vPos.z)){
-					G2LQ(vPos.x,vPos.y,vPos.z,tx,ty);
+					G2LQ(vPos,tx,ty);
 	//				G2L(vPos.x,vPos.y,tx,ty);
 					if(tx > UcutLeft && tx < UcutRight && ty > VcutUp && ty < VcutDown) XGR_SetPixelFast(tx,ty,p->Color >> 8);
 				};
@@ -1366,7 +1366,7 @@ void TargetParticleType::aQuant(void)
 //		vR.y &= PTrack_mask_y;
 		pDist = d;
 
-		G2LQ(vR.x >> 8,vR.y >> 8,vR.z,tx,ty);
+		G2LQ(Vector(vR.x >> 8,vR.y >> 8,vR.z),tx,ty);
 		if(tx > UcutLeft && tx < UcutRight && ty > VcutUp && ty < VcutDown) XGR_SetPixelFast(tx,ty,Color);
 	};
 };
@@ -1502,9 +1502,9 @@ void TargetParticleType::aQuant2(void)
 		vT = vD;
 	}
 
-	G2LQ(vR.x >> 8,vR.y >> 8,vR.z,tx,ty);
+	G2LQ(Vector(vR.x >> 8,vR.y >> 8,vR.z),tx,ty);
 	if(tx > UcutLeft && tx < UcutRight && ty > VcutUp && ty < VcutDown) XGR_SetPixelFast(tx,ty,Color);
-};     
+};
 
 
 void TargetParticleType::sQuant2(void)
@@ -1656,7 +1656,7 @@ void WaterParticleObject::DrawQuant(void)
 					vPos = p->vR;
 					vPos >>= 8;
 					if(WaterAltLevel(vPos.x,vPos.y,vPos.z)){
-						G2L(vPos.x,vPos.y,tx,ty);
+						G2L(vPos,tx,ty);
 						if(tx > UcutLeft && tx < UcutRight && ty > VcutUp && ty < VcutDown) XGR_SetPixelFast(tx,ty,p->Color >> 8);
 					};
 				};
@@ -1680,7 +1680,7 @@ void WaterParticleObject::DrawQuant(void)
 					vPos = p->vR;
 					vPos >>= 8;
 					if(GetAltLevel(vPos.x,vPos.y,vPos.z)){
-						G2L(vPos.x,vPos.y,tx,ty);
+						G2L(vPos,tx,ty);
 						if(tx > UcutLeft && tx < UcutRight && ty > VcutUp && ty < VcutDown) XGR_SetPixelFast(tx,ty,p->Color >> 8);
 					};
 				};
@@ -1707,7 +1707,7 @@ void WaterParticleObject::DrawQuant(void)
 					vPos = p->vR;
 					vPos >>= 8;
 					if(WaterAltLevel(vPos.x,vPos.y,vPos.z)){
-						G2L(vPos.x,vPos.y,tx,ty);
+						G2L(vPos,tx,ty);
 						if(tx > UcutLeft && tx < UcutRight && ty > VcutUp && ty < VcutDown) XGR_SetPixelFast(tx,ty,p->Color >> 8);
 					};
 				};
@@ -1732,7 +1732,7 @@ void WaterParticleObject::DrawQuant(void)
 					vPos = p->vR;
 					vPos >>= 8;
 					if(GetAltLevel(vPos.x,vPos.y,vPos.z)){
-						G2L(vPos.x,vPos.y,tx,ty);
+						G2L(vPos,tx,ty);
 						if(tx > UcutLeft && tx < UcutRight && ty > VcutUp && ty < VcutDown) XGR_SetPixelFast(tx,ty,p->Color >> 8);
 					};
 				};
@@ -1857,8 +1857,8 @@ void FireBallObject::Quant(void)
 void FireBallObject::DrawQuant(void)
 {
 	int tx,ty,s;
-	if(AdvancedView) s = G2LF(R_curr.x,R_curr.y,R_curr.z,tx,ty);
-	else s = G2LS(R_curr.x,R_curr.y,R_curr.z,tx,ty);
+	if(AdvancedView) s = G2LF(R_curr,tx,ty);
+	else s = G2LS(R_curr,tx,ty);
 	s = s * Scale;
 //	FBP->Show(tx,ty,R_curr.z,s << 7,frame);
 	FBP->Show(tx,ty,R_curr.z,s,frame);

--- a/src/units/effect.cpp
+++ b/src/units/effect.cpp
@@ -1655,7 +1655,7 @@ void WaterParticleObject::DrawQuant(void)
 					p->dColor = DeltaColor;
 					vPos = p->vR;
 					vPos >>= 8;
-					if(WaterAltLevel(vPos.x,vPos.y,vPos.z)){
+					if(WaterAltLevel(vPos)){
 						G2L(vPos,tx,ty);
 						if(tx > UcutLeft && tx < UcutRight && ty > VcutUp && ty < VcutDown) XGR_SetPixelFast(tx,ty,p->Color >> 8);
 					};
@@ -1666,7 +1666,7 @@ void WaterParticleObject::DrawQuant(void)
 					p->dColor = DeltaColor;
 					vPos = p->vR;
 					vPos >>= 8;
-					if(WaterAltLevel(vPos.x,vPos.y,vPos.z)){
+					if(WaterAltLevel(vPos)){
 						tx = ((int)round(SPGetDistX(p->vR.x,SPViewX) * ScaleMapInvFlt) >> 8) + ScreenCX;
 						ty = ((int)round((p->vR.y - SPViewY) * ScaleMapInvFlt) >> 8)+ ScreenCY;
 						if(tx > UcutLeft && tx < UcutRight && ty > VcutUp && ty < VcutDown) XGR_SetPixelFast(tx,ty,p->Color >> 8);
@@ -1706,7 +1706,7 @@ void WaterParticleObject::DrawQuant(void)
 					p->dColor = DeltaColor;
 					vPos = p->vR;
 					vPos >>= 8;
-					if(WaterAltLevel(vPos.x,vPos.y,vPos.z)){
+					if(WaterAltLevel(vPos)){
 						G2L(vPos,tx,ty);
 						if(tx > UcutLeft && tx < UcutRight && ty > VcutUp && ty < VcutDown) XGR_SetPixelFast(tx,ty,p->Color >> 8);
 					};
@@ -1717,7 +1717,7 @@ void WaterParticleObject::DrawQuant(void)
 					p->dColor = DeltaColor;
 					vPos = p->vR;
 					vPos >>= 8;
-					if(WaterAltLevel(vPos.x,vPos.y,vPos.z)){
+					if(WaterAltLevel(vPos)){
 						tx = ((int)round(SPGetDistX(p->vR.x,SPViewX) * ScaleMapInvFlt) >> 8) + ScreenCX;
 						ty = ((int)round((p->vR.y - SPViewY) * ScaleMapInvFlt) >> 8)+ ScreenCY;
 
@@ -1810,15 +1810,15 @@ void WaterParticleObject::CreateParticle(int _LifeTime,int _SetLifeTime,int _Vel
 	};
 };
 
-int WaterAltLevel(int x,int y,int z)
+int WaterAltLevel(Vector v)
 {
-	uchar* p = vMap->lineT[y];
+	uchar* p = vMap->lineT[v.y];
 	uchar* t;
 	if(p){
-		p += x;
+		p += v.x;
 		t = p + H_SIZE;
 		if((*t) & DOUBLE_LEVEL){
-			if(x & 1){
+			if(v.x & 1){
 				return (GET_TERRAIN_TYPE(*t) == WATER_TERRAIN);
 			}else{
 				return (GET_TERRAIN_TYPE(*(t + 1)) == WATER_TERRAIN);

--- a/src/units/effect.h
+++ b/src/units/effect.h
@@ -239,7 +239,7 @@ struct EffectDispatcher : UnitList
 
 int GetAltLevel(Vector v);
 //char GetAltLevel(int x,int y,int z);
-int WaterAltLevel(int x,int y,int z);
+int WaterAltLevel(Vector v);
 //char WaterAltLevel(int x,int y,int z);
 
 extern EffectDispatcher EffD;

--- a/src/units/effect.h
+++ b/src/units/effect.h
@@ -237,7 +237,7 @@ struct EffectDispatcher : UnitList
 	void CreateParticleGenerator(Vector vC,Vector vT,Vector vD,int mode = PG_STYLE_INCAR);
 };
 
-int GetAltLevel(int x,int y,int z);
+int GetAltLevel(Vector v);
 //char GetAltLevel(int x,int y,int z);
 int WaterAltLevel(int x,int y,int z);
 //char WaterAltLevel(int x,int y,int z);

--- a/src/units/hobj.cpp
+++ b/src/units/hobj.cpp
@@ -1679,20 +1679,21 @@ uchar GetAlt(int x,int y,int z,uchar& alt)
 	return 1;
 };
 
-
-int BigGetAlt(int x,int y,int z,uchar& alt,uchar terrain)
+int BigGetAlt(Vector v, uchar& alt, uchar terrain)
 {
-	uchar* p = vMap->lineT[y];
-	if(p){
-		p += x;
+	uchar* p = vMap->lineT[v.y];
+	if (p) {
+		p += v.x;
 		alt = *p;
-		if(GET_TERRAIN(*(p + H_SIZE)) == terrain)
+		if (GET_TERRAIN(*(p + H_SIZE)) == terrain)
 			return 1;
-		else 
+		else
 			return 0;
-	}else alt = 0;
+	} else {
+		alt = 0;
+	}
 	return 0;
-};
+}
 
 int TouchSphere(Vector& r0,Vector& r1,Vector& c,int rad,int& r)
 {
@@ -2717,6 +2718,11 @@ void ChangeWorld(int world,int flag)
 //		}
 };*/
 
+void G2L(Vector v,int& xl,int& yl)
+{
+	G2L(v.x, v.y, xl, yl);
+};
+
 void G2L(int x,int y,int& xl,int& yl)
 {
 	x = getDistX(x,ViewX);
@@ -2726,47 +2732,65 @@ void G2L(int x,int y,int& xl,int& yl)
 	yl = round((x*sinTurnFlt + y*cosTurnFlt)) + ScreenCY;
 };
 
-int G2LS(int x,int y,int z,int& sx,int& sy)
+int G2LS(Vector v,int& sx,int& sy)
 {
-	int z1;
-	sx = round(getDistX(x,ViewX)*ScaleMapInvFlt) + ScreenCX;
-	sy = round(getDistY(y,ViewY)*ScaleMapInvFlt) + ScreenCY;
-	z1 = ViewZ - (z >> 1);
-	if(z1 <= 0) z1 = 1;
-//	return((focus << 8)/(-((int)z >> 1) + ViewZ));
-	return(focus << 8)/z1;
+	return G2LS(v.x, v.y, v.z, sx, sy);
 };
 
-void G2LP(int x,int y,int z,int& sx,int& sy)
+int G2LS(int x,int y,int z,int& sx,int& sy)
+{
+	sx = round(getDistX(x,ViewX)*ScaleMapInvFlt) + ScreenCX;
+	sy = round(getDistY(y,ViewY)*ScaleMapInvFlt) + ScreenCY;
+	int _z = ViewZ - (z >> 1);
+	if(_z <= 0) _z = 1;
+	return (focus << 8) / _z;
+};
+
+void G2LP(Vector v, int& sx, int& sy)
+{
+	G2LP(v.x, v.y, sx, sy);
+};
+
+void G2LP(int x,int y,int& sx,int& sy)
 {
 	sx = getDistX(x,ViewX) + ScreenCX;
 	sy = getDistY(y,ViewY) + ScreenCY;
 };
 
-void G2LQ(int x,int y,int z,int& sx,int& sy)
+void G2LQ(Vector v, int& sx, int &sy)
 {
-	z = 0;
+	G2LQ(v.x, v.y, sx, sy);
+};
+
+void G2LQ(int x, int y, int& sx, int &sy)
+{
+	int z = 0;
 	int xx = getDistX(x,ViewX);
 	int yy = getDistY(y,ViewY);
 	double x1 = A_g2s.a[0]*xx + A_g2s.a[1]*yy - A_g2s.a[2]*z;
 	double y1 = A_g2s.a[3]*xx + A_g2s.a[4]*yy - A_g2s.a[5]*z;
 	double z1 = ViewZ + (A_g2s.a[6]*xx + A_g2s.a[7]*yy -A_g2s.a[7]*z)*0.5;
-	if(z1 <= 0) 
+	if (z1 <= 0)
 		z1 = 1;
 	z1 = focus_flt/z1;
 	sx = round(x1*z1) + ScreenCX;
 	sy = round(y1*z1) + ScreenCY;
 };
 
-int G2LF(int x,int y,int z,int& sx,int& sy)
+int G2LF(Vector v,int& sx,int& sy)
 {
-	z = 0;
+	return G2LF(v.x, v.y, sx, sy);
+};
+
+int G2LF(int x,int y,int& sx,int& sy)
+{
+	int z = 0;
 	int xx = getDistX(x,ViewX);
 	int yy = getDistY(y,ViewY);
 	double x1 = round(A_g2s.a[0]*xx + A_g2s.a[1]*yy - A_g2s.a[2]*z);
 	double y1 = round(A_g2s.a[3]*xx + A_g2s.a[4]*yy - A_g2s.a[5]*z);
 	double z1 = ViewZ + round((A_g2s.a[6]*xx + A_g2s.a[7]*yy -A_g2s.a[7]*z)*.5);
-	if(z1 <= 0) 
+	if (z1 <= 0)
 		z1 = 1;
 	z1 = focus_flt/z1;
 	sx = round(x1*z1) + ScreenCX;
@@ -3015,11 +3039,11 @@ void ScreenLineTrace(Vector& v0,Vector& v1,uchar* ColorTable,uchar flag)
 	v1.x = XCYCL(v1.x);
 
 	if(AdvancedView){
-		G2LQ(v0.x,v0.y,v0.z,x0,y0);
-		G2LQ(v1.x,v1.y,v1.z,x1,y1);
+		G2LQ(v0,x0,y0);
+		G2LQ(v1,x1,y1);
 	}else{
-		G2LP(v0.x,v0.y,v0.z,x0,y0);
-		G2LP(v1.x,v1.y,v1.z,x1,y1);
+		G2LP(v0,x0,y0);
+		G2LP(v1,x1,y1);
 	};
 
 	dx = x1 - x0;

--- a/src/units/hobj.cpp
+++ b/src/units/hobj.cpp
@@ -1627,24 +1627,24 @@ char GetMapLevelType(Vector& v,uchar*& type)
 	return -1;
 };
 
-uchar GetAlt(int x,int y,int z,uchar& alt)
+uchar GetAlt(Vector v,uchar& alt)
 {
-	uchar* p = vMap->lineT[y];
+	uchar* p = vMap->lineT[v.y];
 	uchar* t;
 	uchar d;
 	if(p){
-		p += x;
+		p += v.x;
 		t = p + H_SIZE;
 		if((*t) & DOUBLE_LEVEL){
-			if(x & 1){
-				if((*p) < z){
+			if(v.x & 1){
+				if((*p) < v.z){
 					alt = *p;
 					return 1;
 				};
 
 				d = *(p -1);
-				if(d < z){
-					if((d + (((GET_DELTA(*(t - 1)) << 2) + GET_DELTA(*t) + 1) << DELTA_SHIFT)) > z){
+				if(d < v.z){
+					if((d + (((GET_DELTA(*(t - 1)) << 2) + GET_DELTA(*t) + 1) << DELTA_SHIFT)) > v.z){
 						alt = d;
 						return 0;
 					}else{
@@ -1656,13 +1656,13 @@ uchar GetAlt(int x,int y,int z,uchar& alt)
 					return 0;
 				};
 			}else{
-				if(*(p + 1) < z){
+				if(*(p + 1) < v.z){
 					alt = *(p + 1);
 					return 1;
 				};
 				d = *p;
-				if(d < z){
-					if((d + (((GET_DELTA(*t) << 2) + GET_DELTA(*(t + 1)) + 1) << DELTA_SHIFT)) > z){
+				if(d < v.z){
+					if((d + (((GET_DELTA(*t) << 2) + GET_DELTA(*(t + 1)) + 1) << DELTA_SHIFT)) > v.z){
 						alt = d;
 						return 0;
 					}else{

--- a/src/units/hobj.cpp
+++ b/src/units/hobj.cpp
@@ -3080,8 +3080,11 @@ void ScreenLineTrace(Vector& v0,Vector& v1,uchar* ColorTable,uchar flag)
 
 				ty = cy >> FIXED_SHIFT;
 				if(cx > UcutLeft && cx < UcutRight && ty > VcutUp && ty < VcutDown){
-					if(GetAltLevel(vC.x >> FIXED_SHIFT,vC.y >> FIXED_SHIFT,vC.z >> FIXED_SHIFT))
-						XGR_SetPixel(cx,ty,ColorTable[XGR_GetPixel(cx,ty) + l]);
+					if(GetAltLevel(Vector(
+						vC.x >> FIXED_SHIFT,
+						vC.y >> FIXED_SHIFT,
+						vC.z >> FIXED_SHIFT))
+					){ XGR_SetPixel(cx,ty,ColorTable[XGR_GetPixel(cx,ty) + l]); };
 				};
 				cx++;
 				cy += k;
@@ -3116,8 +3119,11 @@ void ScreenLineTrace(Vector& v0,Vector& v1,uchar* ColorTable,uchar flag)
 
 				tx = cx >> FIXED_SHIFT;
 				if(tx > UcutLeft && tx < UcutRight && cy > VcutUp && cy < VcutDown){
-					if(GetAltLevel(vC.x >> FIXED_SHIFT,vC.y >> FIXED_SHIFT,vC.z >> FIXED_SHIFT))
-						XGR_SetPixel(tx,cy,ColorTable[XGR_GetPixel(tx,cy) + l]);
+					if(GetAltLevel(Vector(
+						vC.x >> FIXED_SHIFT,
+						vC.y >> FIXED_SHIFT,
+						vC.z >> FIXED_SHIFT))
+					){ XGR_SetPixel(tx,cy,ColorTable[XGR_GetPixel(tx,cy) + l]); };
 				};
 				cy++;
 				cx += k;
@@ -3158,8 +3164,11 @@ void ScreenLineTrace(Vector& v0,Vector& v1,uchar* ColorTable,uchar flag)
 
 				ty = cy >> FIXED_SHIFT;
 				if(cx > UcutLeft && cx < UcutRight && ty > VcutUp && ty < VcutDown){
-					if(GetAltLevel(vC.x >> FIXED_SHIFT,vC.y >> FIXED_SHIFT,vC.z >> FIXED_SHIFT))
-						XGR_SetPixel(cx,ty,ColorTable[XGR_GetPixel(cx,ty) + (l & 0xffffff00)]);
+					if(GetAltLevel(Vector(
+						vC.x >> FIXED_SHIFT,
+						vC.y >> FIXED_SHIFT,
+						vC.z >> FIXED_SHIFT))
+					){ XGR_SetPixel(cx,ty,ColorTable[XGR_GetPixel(cx,ty) + (l & 0xffffff00)]); };
 				};
 
 				cx++;
@@ -3202,8 +3211,11 @@ void ScreenLineTrace(Vector& v0,Vector& v1,uchar* ColorTable,uchar flag)
 
 				tx = cx >> FIXED_SHIFT;
 				if(tx > UcutLeft && tx < UcutRight && cy > VcutUp && cy < VcutDown){
-					if(GetAltLevel(vC.x >> FIXED_SHIFT,vC.y >> FIXED_SHIFT,vC.z >> FIXED_SHIFT))
-						XGR_SetPixel(tx,cy,ColorTable[XGR_GetPixel(tx,cy) + (l & 0xffffff00)]);
+					if(GetAltLevel(Vector(
+						vC.x >> FIXED_SHIFT,
+						vC.y >> FIXED_SHIFT,
+						vC.z >> FIXED_SHIFT))
+					){ XGR_SetPixel(tx,cy,ColorTable[XGR_GetPixel(tx,cy) + (l & 0xffffff00)]); };
 				};
 				cy++;
 				cx += k;

--- a/src/units/hobj.h
+++ b/src/units/hobj.h
@@ -190,16 +190,21 @@ void putMapPixel(int px,int py,int col);
 //void line_trace(const Vector& c1,const Vector& c2);
 
 void G2L(int x,int y,int& xl,int& yl);
+void G2L(Vector v,int& xl,int& yl);
 int MapLineTrace(Vector& c1,Vector& c2);
 char GetCollisionMap(int x,int y,int z);
 char GetMapLevel(Vector& v);
 uchar GetAlt(int x,int y,int z,uchar& alt);
 uchar GetGlobalAlt(int x,int y);
 
+int G2LS(Vector v,int& sx,int& sy);
 int G2LS(int x,int y,int z,int& sx,int& sy);
-int G2LF(int x,int y,int z,int& sx,int& sy);
-void G2LQ(int x,int y,int z,int& sx,int& sy);
-void G2LP(int x,int y,int z,int& sx,int& sy);
+int G2LF(Vector v,int& sx,int& sy);
+int G2LF(int x,int y,int& sx,int& sy);
+void G2LQ(Vector v,int& sx,int& sy);
+void G2LQ(int x,int y,int& sx,int& sy);
+void G2LP(Vector v,int& sx,int& sy);
+void G2LP(int x,int y,int& sx,int& sy);
 void S2G(int xs,int ys,int& xg,int& yg);
 
 //void SetMapBuff(int x,int y,int x_size,int y_size,uchar* MapBuf);
@@ -215,7 +220,7 @@ int TouchSphereZ(Vector& r0,Vector& r1,Vector& c,int rad,int& r);
 void DrawShadow(int x,int y,int x_size,int y_size,uchar* buff);
 
 char GetMapLevelType(Vector& v,uchar*& type);
-int BigGetAlt(int x,int y,int z,uchar& alt,uchar terrain);
+int BigGetAlt(Vector v,uchar& alt,uchar terrain);
 
 extern char SetWorldFlag;
 extern int CurrentWorld;

--- a/src/units/hobj.h
+++ b/src/units/hobj.h
@@ -194,7 +194,7 @@ void G2L(Vector v,int& xl,int& yl);
 int MapLineTrace(Vector& c1,Vector& c2);
 char GetCollisionMap(int x,int y,int z);
 char GetMapLevel(Vector& v);
-uchar GetAlt(int x,int y,int z,uchar& alt);
+uchar GetAlt(Vector v,uchar& alt);
 uchar GetGlobalAlt(int x,int y);
 
 int G2LS(Vector v,int& sx,int& sy);

--- a/src/units/items.cpp
+++ b/src/units/items.cpp
@@ -1566,7 +1566,7 @@ void BulletObject::TimeOutQuant(void)
 			};
 		}else{
 			if(ShowID == BULLET_SHOW_TYPE_ID::CRATER && ExtShowType){
-				if(BigGetAlt(R_curr.x,R_curr.y,R_curr.z,alt,ExtShowType)) MapLevel = 1;
+				if(BigGetAlt(R_curr, alt, ExtShowType)) MapLevel = 1;
 				else{
 					MapLevel = 0;
 					alt = 0;
@@ -1648,8 +1648,8 @@ void BulletObject::DrawQuant(void)
 				EffD.CreateParticle(ExtShowType,R_prev,R_curr,ShowType);
 			break;
 		case BULLET_SHOW_TYPE_ID::FIREBALL:
-			if(AdvancedView) s = G2LF(R_curr.x,R_curr.y,R_curr.z,tx,ty);
-			else s = G2LS(R_curr.x,R_curr.y,R_curr.z,tx,ty);
+			if(AdvancedView) s = G2LF(R_curr,tx,ty);
+			else s = G2LS(R_curr,tx,ty);
 //!!!!!!!!!
 			s *= BulletScale;
 			EffD.FireBallData[ShowType].Show(tx,ty,R_curr.z,s,FrameCount);
@@ -1660,8 +1660,8 @@ void BulletObject::DrawQuant(void)
 				LightData = MapD.CreateLight(R_curr.x,R_curr.y,R_curr.z,40,32,LIGHT_TYPE::DYNAMIC);
 			break;
 		case BULLET_SHOW_TYPE_ID::DEFORM:
-			if(AdvancedView) s = G2LF(R_curr.x,R_curr.y,R_curr.z,tx,ty);
-			else s = G2LS(R_curr.x,R_curr.y,R_curr.z,tx,ty);
+			if(AdvancedView) s = G2LF(R_curr,tx,ty);
+			else s = G2LS(R_curr,tx,ty);
 			if(EffD.DeformData[ShowType].CheckOffset(FrameCount)) FrameCount = 0;
 			EffD.DeformData[ShowType].Deform(tx,ty,FrameCount,1);
 			break;
@@ -2892,7 +2892,7 @@ void HordeObject::DrawQuant(void)
 			p->QuantP(R_curr << 8, vDelta << 8,3 << 8,5);
 			vPos = p->vR;
 			vPos >>= 8;
-			G2LQ(vPos.x,vPos.y,vPos.z,tx,ty);
+			G2LQ(vPos,tx,ty);
 			if(tx > UcutLeft && tx < UcutRight && ty > VcutUp && ty < VcutDown) XGR_SetPixelFast(tx,ty,p->Color >> 8);
 		};
 	}else{

--- a/src/units/items.cpp
+++ b/src/units/items.cpp
@@ -1575,7 +1575,7 @@ void BulletObject::TimeOutQuant(void)
 						LightData = NULL;
 					};
 				};
-			}else MapLevel = GetAlt(R_curr.x,R_curr.y,R_curr.z,alt);			
+			}else MapLevel = GetAlt(R_curr,alt);
 			R_curr.z = alt + AltOffset;
 		};
 	}else{

--- a/src/units/mechos.cpp
+++ b/src/units/mechos.cpp
@@ -8634,8 +8634,8 @@ void CompasObject::Quant(void)
 	v = Vector(ActD.Active->Speed,0,0)*ActD.Active->RotMat;
 	x = XCYCL(x + vMove.x + v.x);
 	y = YCYCL(y + vMove.y + v.y);
-	if(AdvancedView) G2LQ(x,y,0,tx,ty);
-	else G2LS(x,y,0,tx,ty);
+	if(AdvancedView) G2LQ(Vector(x,y,0),tx,ty);
+	else G2LS(Vector(x,y,0),tx,ty);
 
 	if(tx < UcutLeft + COMPAS_LEFT){
 		tx = UcutLeft + COMPAS_LEFT;


### PR DESCRIPTION
3/3 #431

Removed gcc warnings `unused-parameter` by changing signature of functions:
from `fn(int x, int y, int z, ...)` to `fn(Vector v, ...)` where parameter `z` is never used in real. Also I changed signatures of some similar functions.
