### PR TITLE
Removed useless assign value

### DIFF
--- a/src/uvs/univang.cpp
+++ b/src/uvs/univang.cpp
@@ -8600,7 +8600,6 @@ void uniVangLoad(XStream &pfile){
 		(v = new uvsVanger(pfile));
 		if( v -> shape == UVS_VANGER_SHAPE::GAMER  ){
 			Gamer = v;
-			v -> shape = UVS_VANGER_SHAPE::GAMER;
 		}
 		v -> elink(ETail);
 	}


### PR DESCRIPTION
```
if (a == 1) {
    a = 1;
}
```