### PR TITLE
Сообщения в мире не отображаются если нажата кнопка "Всем молчать"

### DIFF
--- a/src/iscreen/i_chat.h
+++ b/src/iscreen/i_chat.h
@@ -6,6 +6,8 @@
 // iChatScreenObject::flags...
 #define ICS_HIDDEN_OBJECT	0x01
 
+extern int iChatMUTE;
+
 struct iChatScreenObject : XListElement
 {
 	int ID;

--- a/src/road.cpp
+++ b/src/road.cpp
@@ -66,6 +66,7 @@
 #include "iscreen/hfont.h"
 #include "iscreen/iscreen.h"
 #include "iscreen/controls.h"
+#include "iscreen/i_chat.h"
 #include "actint/actint.h"
 #endif
 
@@ -1980,13 +1981,15 @@ void iGameMap::draw(int self)
 
 				zChat.init();
 				zChat < msg->message;
-				zchatfont.draw(
-					xc-xside+80,
-					yc-yside+20+(zCHAT_ROWLIMIT*zCHAT_ROWHEIGHT)-(zCount*zCHAT_ROWHEIGHT),
-					(unsigned char*)(zChat.GetBuf()),
-					zColor, 
-					zCOLOR_TRANSPARENT
-				);
+				if (!iChatMUTE) {
+					zchatfont.draw(
+						xc-xside+80,
+						yc-yside+20+(zCHAT_ROWLIMIT*zCHAT_ROWHEIGHT)-(zCount*zCHAT_ROWHEIGHT),
+						(unsigned char*)(zChat.GetBuf()),
+						zColor, 
+						zCOLOR_TRANSPARENT
+					);
+				}
 
 				if(msg == message_dispatcher.first()) break;
 				msg = (MessageElement*)msg->prev;


### PR DESCRIPTION
Если сейчас нажать кнопку "Всем молчать", то сообщения в окне чата пропадут и не будут появляться до момента, когда еще раз нажмешь на кнопку, НО в мире будут появляться сообщения (левый верхний угол), хотя такого явно быть не должно. Теперь при нажатии "Всем молчать" сообщения помимо чата пропадают и в мире