### PR TITLE
Fix function without return statement

### DIFF
--- a/surmap/missed.cpp
+++ b/surmap/missed.cpp
@@ -111,7 +111,7 @@ char* win32_findnext() {
 }
 
 // we should still rely on gcc 5
-std::string replace_all(std::string& str, const std::string& from, const std::string& to) {
+void replace_all(std::string& str, const std::string& from, const std::string& to) {
     size_t start_pos = 0;
     while((start_pos = str.find(from, start_pos)) != std::string::npos) {
         str.replace(start_pos, from.length(), to);


### PR DESCRIPTION
Non-void functions without return statement are really dangerous!

```
[ 56%] Building CXX object surmap/CMakeFiles/surmap.dir/missed.cpp.o
/sources/Vangers-470654b738761a63546ef0fa625f85f79daa72fa/surmap/missed.cpp: In function 'std::string replace_all(std::string&, const string&, const string&)':
/sources/Vangers-470654b738761a63546ef0fa625f85f79daa72fa/surmap/missed.cpp:120:1: warning: no return statement in function returning non-void [-Wreturn-type]
}
^
```

Cool story with similar bug: https://www.linux.org.ru/forum/development/15906872