### PR TITLE
Bullet freeze fix

### DIFF
--- a/src/units/items.cpp
+++ b/src/units/items.cpp
@@ -1322,7 +1322,7 @@ void BulletObject::CreateBullet(GunSlot* p,WorldBulletTemplate* n)
 	if(BulletMode & BULLET_CONTROL_MODE::SPEED) Speed += (int)round(p->RealSpeed / GAME_TIME_COEFF);
 
 	if(BulletID == BULLET_TYPE_ID::LASER)
-		vDelta = Vector(Speed,(3 - (int)(RND(6)))/GAME_TIME_COEFF,0)*p->mFire; //machotine bullet dispersion
+		vDelta = Vector(Speed,(3 - (int)(RND(6))),0)*p->mFire; //machotine bullet dispersion
 	else 
 		vDelta = Vector(Speed,0,0)*p->mFire;
 

--- a/src/units/items.cpp
+++ b/src/units/items.cpp
@@ -1322,7 +1322,7 @@ void BulletObject::CreateBullet(GunSlot* p,WorldBulletTemplate* n)
 	if(BulletMode & BULLET_CONTROL_MODE::SPEED) Speed += (int)round(p->RealSpeed / GAME_TIME_COEFF);
 
 	if(BulletID == BULLET_TYPE_ID::LASER)
-		vDelta = Vector(Speed,(3 - RND(6))/GAME_TIME_COEFF,0)*p->mFire; //machotine bullet dispersion
+		vDelta = Vector(Speed,(3 - (int)(RND(6)))/GAME_TIME_COEFF,0)*p->mFire; //machotine bullet dispersion
 	else 
 		vDelta = Vector(Speed,0,0)*p->mFire;
 


### PR DESCRIPTION
1. Fixes freezes on machotene shooting. The problem was in invalid type coersion `(int - uint)/double = uint`. Was fixed by explicit int casting
2. Fixes invalid machotine spread calculation. There's no need to normalize by `GAME_TIME_COEFF` since this logic is not frame time related.

Fixes #518 