### PR TITLE
Dust for 60FPS

### DIFF
--- a/src/3d/dynamics.cpp
+++ b/src/3d/dynamics.cpp
@@ -3085,7 +3085,7 @@ void Object::mechous_analysis(double dt)
 	hand_brake = turbo = brake = 0;
 	if(rudder && dynamic_state & WHEELS_TOUCH)
 		rudder -= SIGN(rudder) * fabs(round(rudder*V.y*dt*num_calls_analysis*rudder_k_decr) + 1);
-	speed = round(V.vabs()*dt*num_calls_analysis);
+	speed = round(V.vabs()*dt*num_calls_analysis * GAME_TIME_COEFF);
 }
 
 //stalkerg: а ещё важнее физика тут
@@ -3596,7 +3596,7 @@ void Object::debris_analysis(double dt)
 //		R = R_old;
 		}
 	after_db_coll--;
-	speed = round(V.vabs()*dt*num_calls_analysis);
+	speed = round(V.vabs()*dt*num_calls_analysis * GAME_TIME_COEFF);
 }
 
 void Object::basic_debris_analysis(double dt)

--- a/src/particle/particle.cpp
+++ b/src/particle/particle.cpp
@@ -19,6 +19,7 @@ const int PART_H_SIZE = H_SIZE>>PARTICLE_SHIFT;
 unsigned BogusRNDVAL = 83838383;
 
 void ParticleProcess::quant1(){
+	BackD.put(this);
 	ListExhausted = 0;
 	GetBackGround();
 	express();
@@ -47,8 +48,6 @@ void ParticleProcess::quant2(){
 	for(p = ActivList.next;p != &ActivList; p = p -> next){
 		p -> valueDecrease();
 	}
-	BackD.put(this);
-	//GetBackGround();
 }
 
 void Particle::process(ParticleProcess* proc){

--- a/src/particle/particle.cpp
+++ b/src/particle/particle.cpp
@@ -8,6 +8,8 @@
 #include "../terra/vmap.h"
 #include "../terra/world.h"
 
+#include "../runtime.h"
+
 #include "particle.h"
 #include "partmap.h"
 
@@ -391,8 +393,9 @@ void Particle::express(ParticleProcess* proc){
 	uchar **lt = vMap -> lineT;
 	uchar **ltc = vMap -> lineTcolor;
 	uchar *ParticlePaletteTable;
-	const int noise = 4;
-	//const int noise = 2;
+
+	// lower noise for FPS=60
+	const int noise = GAME_TIME_COEFF > 0 ? 2 : 4;
 
 	switch(proc -> PaletteColor){
 	case 0 :

--- a/src/particle/particle.cpp
+++ b/src/particle/particle.cpp
@@ -44,6 +44,9 @@ void ParticleProcess::quant2(){
 	for( p = NewParticles -> next; p != &ActivList; p = p -> next)
 		p -> delFromCol(this);
 
+	for(p = ActivList.next;p != &ActivList; p = p -> next){
+		p -> valueDecrease();
+	}
 	BackD.put(this);
 	//GetBackGround();
 }
@@ -365,21 +368,6 @@ void ParticleProcess::finit(){
 }
 
 void Particle::purge(ParticleProcess* proc){
-	Value = ((3*NewValue >> 3) + Value)>>2;
-
-	switch(RND(13)){
-			case 0: break;
-			case 1:  if(U)  Value = ((3*U -> NewValue >>3) + Value)>>2; break;
-			case 2: break;
-			case 3: if(L)  Value = ((3*L -> NewValue >>3) + Value)>>2; break;
-			case 4: break;
-			case 5: if(R) Value = ((3*R -> NewValue >>3) + Value)>>2; break;
-			case 6:  break;
-			case 7:  if(D)  Value = ((3*D -> NewValue >>3) + Value)>>2; break;
-			case 8: break;
-		}
-	
-	Protected = 0;
 	if(!Value){
 		if(*BackGround){
 			int _X = X<<PARTICLE_SHIFT;
@@ -585,6 +573,25 @@ void Particle::GetBackGround(void){
 		if( lt[y] )
 			memcpy(BackGround+(j<<2),ltc[y] + _X,PARTICLE_SIZE);
 	}
+}
+
+void Particle::valueDecrease()
+{
+	Value = ((3*NewValue >> 3) + Value)>>2;
+
+	switch(RND(13)){
+		case 0: break;
+		case 1:  if(U)  Value = ((3*U -> NewValue >>3) + Value)>>2; break;
+		case 2: break;
+		case 3: if(L)  Value = ((3*L -> NewValue >>3) + Value)>>2; break;
+		case 4: break;
+		case 5: if(R) Value = ((3*R -> NewValue >>3) + Value)>>2; break;
+		case 6:  break;
+		case 7:  if(D)  Value = ((3*D -> NewValue >>3) + Value)>>2; break;
+		case 8: break;
+	}
+
+	Protected = 0;
 }
 
 uchar *ParticlePaletteTableDust;

--- a/src/particle/particle.h
+++ b/src/particle/particle.h
@@ -47,6 +47,8 @@ struct Particle{
 
 	void BackRestore(void);
 	void GetBackGround(void);
+
+	void valueDecrease();
 };
 
 

--- a/src/units/hobj.cpp
+++ b/src/units/hobj.cpp
@@ -1817,6 +1817,11 @@ void TrackUnit::DrawMechosParticle(int x,int y,int speed,int level,int n)
 			};
 		};
 
+		// 60PFS: Creating dust at 20FPS
+		if(frame % (int)GAME_TIME_COEFF > 0){
+			return;
+		}
+
 		if((int)(RND(10)) > speed) return;
 
 		if(trn == 1) 

--- a/src/units/hobj.cpp
+++ b/src/units/hobj.cpp
@@ -1763,8 +1763,14 @@ void VangerUnit::DrawMechosParticle(int x,int y,int speed,int level,int n)
 {
 	if(ExternalMode != EXTERNAL_MODE_NORMAL || !ExternalDraw)
 		return;
-	if(Armor < MaxArmor && (int)(RND(MaxArmor)) > Armor && (int)(RND(MaxArmor)) > Armor)
-		MapD.CreateDust(Vector(x,y,level), (int)MAP_SMOKE_PROCESS);
+
+	if(Armor < MaxArmor && 
+		frame % (int)GAME_TIME_COEFF == 0 &&
+		(int)(RND(MaxArmor)) > Armor && 
+		(int)(RND(MaxArmor)) > Armor) {
+			MapD.CreateDust(Vector(x,y,level), (int)MAP_SMOKE_PROCESS);
+	}
+		
 	TrackUnit::DrawMechosParticle(x,y,speed,level,n);
 };
 

--- a/src/units/items.cpp
+++ b/src/units/items.cpp
@@ -50,6 +50,7 @@ const char DEBRIS_LIFE_TIME = 100;
 
 //extern XStream MechosLst;
 extern int AdvancedView;
+extern int frame; // kdsplus.cpp
 
 const int MAX_STUFF_SCATTER = 150;
 
@@ -1668,7 +1669,9 @@ void BulletObject::DrawQuant(void)
 			EffD.DeformData[ShowType].Deform(tx,ty,FrameCount,1);
 			break;
 		case BULLET_SHOW_TYPE_ID::DUST:
-			MapD.CreateDust(Vector(R_curr.x,R_curr.y,MapLevel),ShowType);
+			if(frame % (int)GAME_TIME_COEFF == 0){
+				MapD.CreateDust(Vector(R_curr.x, R_curr.y, MapLevel), ShowType);
+			}			
 			break;
 		case BULLET_SHOW_TYPE_ID::CRATER:
 			if(MapLevel && (vDelta.x != 0 || vDelta.y != 0 || vDelta.z != 0)){

--- a/src/units/moveland.cpp
+++ b/src/units/moveland.cpp
@@ -69,6 +69,7 @@ char* win32_findfirst(const char* mask)
 
 
 /* ----------------------------- EXTERN SECTION ---------------------------- */
+extern int frame; // kdsplus.cpp
 extern int ViewX,ViewY;
 extern iGameMap* curGMap;
 extern int MLstatus,MLprocess;
@@ -470,7 +471,9 @@ void LocalMapProcess::Quant(void)
 	for(i = 0;i < NumDustType;i++){
 		Dust[i].quant1();
 		while((p = (MapPointType*)(DustStorage[i].GetAll())) != NULL) Dust[i].set_hot_spot(p->R_curr.x,p->R_curr.y,100,p->R_curr.z);
-		Dust[i].quant2();
+		if(frame % (int)GAME_TIME_COEFF == 0) {
+			Dust[i].quant2();
+		}
 	};
 };
 


### PR DESCRIPTION
fixes #187 

### Changes
* Adjusted `Object::speed` calculation for 60FPS case
* Limited the particle processing rate to 20FPS 
* Limited mechous dust creation to 20FPS 
* Lowered dust visual noise for 60FPS case
* Limited `BULLET_SHOW_TYPE_ID::DUST` dust creation to 20FPS 

### Tested
* Wheels dust
* Smoke
* Protractor ostrich effect

### Not tested
* `BULLET_SHOW_TYPE_ID::DUST` - didn't find a corresponding game object