### PR TITLE
remove throw; workaround for rv_api_1

### DIFF
--- a/lib/renderer/src/renderer/ResourceStorage.h
+++ b/lib/renderer/src/renderer/ResourceStorage.h
@@ -69,7 +69,8 @@ namespace renderer {
 			iterator it = _storage.find(rid);
 
 			if(it == _storage.end()){
-				throw ResourceDoesNotExistsException (rid);
+                printf("Resource does not exists %d\n", rid);
+                abort();
 			}
 			return it;
 		}

--- a/lib/renderer/src/renderer/compositor/gles3/GLES3Compositor.cpp
+++ b/lib/renderer/src/renderer/compositor/gles3/GLES3Compositor.cpp
@@ -352,5 +352,6 @@ void GLES3Compositor::set_logical_screen_size(int32_t width, int32_t height)
 void GLES3Compositor::read_pixels(uint8_t*)
 {
 	// TODO:
-	throw CompositorException("GLES3Compositor::read_pixels is not implemented");
+    printf("GLES3Compositor::read_pixels is not implemented\n");
+    abort();
 }

--- a/lib/renderer/src/renderer/compositor/gles3/GLES3Texture.cpp
+++ b/lib/renderer/src/renderer/compositor/gles3/GLES3Texture.cpp
@@ -22,7 +22,8 @@ GLES3Texture::GLES3Texture(int32_t width, int32_t height, TextureType texture_ty
 	glBindTexture(GL_TEXTURE_2D, _name);
 	gl_error = glGetError();
 	if(gl_error != 0){
-		throw CompositorException(std::string("glBindTexture error: ") + std::to_string(gl_error));
+        printf("%s\n", (std::string("glBindTexture error: ") + std::to_string(gl_error)).c_str());
+        abort();
 	}
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
@@ -39,8 +40,10 @@ GLES3Texture::GLES3Texture(int32_t width, int32_t height, TextureType texture_ty
 		format = GL_RGBA;
 		type = GL_UNSIGNED_BYTE;
 		break;
-	default:
-		throw CompositorException(std::string("Unknown TextureType: ") + std::to_string((int)_texture_type));
+	default: {
+        printf("%s\n", (std::string("Unknown TextureType: ") + std::to_string((int) _texture_type)).c_str());
+        abort();
+    }
 	}
 
 	glTexImage2D(GL_TEXTURE_2D, 0, internalformat, width, height, 0,
@@ -48,7 +51,8 @@ GLES3Texture::GLES3Texture(int32_t width, int32_t height, TextureType texture_ty
 
 	gl_error = glGetError();
 	if(gl_error != 0){
-		throw CompositorException(std::string("glTexImage2D error: ") + std::to_string(gl_error));
+        printf("%s\n", ((std::string("glTexImage2D error: ") + std::to_string(gl_error)).c_str()));
+        abort();
 	}
 
 	glGenerateMipmap(GL_TEXTURE_2D);

--- a/lib/renderer/src/renderer/compositor/gles3/Shader.cpp
+++ b/lib/renderer/src/renderer/compositor/gles3/Shader.cpp
@@ -23,7 +23,8 @@ void Shader::initialize(const char* vs_shader, const char* fs_shader)
 		if(!success){
 			char infoLog[1024];
 			glGetShaderInfoLog(vertex_shader, 1024, nullptr, infoLog);
-			throw CompositorException(std::string("Vertex shader compilation error: " + std::string(infoLog)));
+			printf("%s\n", (std::string("Vertex shader compilation error: " + std::string(infoLog))).c_str());
+			abort();
 		}
 	}
 
@@ -36,7 +37,8 @@ void Shader::initialize(const char* vs_shader, const char* fs_shader)
 		if(!success){
 			char infoLog[1024];
 			glGetShaderInfoLog(fragment_shader, 1024, nullptr, infoLog);
-			throw CompositorException(std::string("Fragment shader compilation error: " + std::string(infoLog)));
+			printf("%s\n", (std::string("Fragment shader compilation error: " + std::string(infoLog))).c_str());
+			abort();
 		}
 	}
 
@@ -49,7 +51,9 @@ void Shader::initialize(const char* vs_shader, const char* fs_shader)
 		glGetProgramiv(_program, GL_LINK_STATUS, &success);
 		if(!success){
 			char infoLog[1024];
-			throw CompositorException(std::string("Program link error: " + std::string(infoLog)));
+			glGetShaderInfoLog(fragment_shader, 1024, nullptr, infoLog);
+			printf("%s\n", (std::string("Program link error: " + std::string(infoLog))).c_str());
+			abort();
 		}
 	}
 	glDeleteShader(vertex_shader);
@@ -59,7 +63,8 @@ void Shader::initialize(const char* vs_shader, const char* fs_shader)
 void Shader::use()
 {
 	if(_program == 0){
-		throw CompositorException("shader is not initialized");
+		printf("shader is not initialized\n");
+		abort();
 	}
 	glUseProgram(_program);
 }
@@ -72,7 +77,8 @@ void Shader::unuse()
 void Shader::set_uniform(const char* name, int value)
 {
 	if(_program == 0){
-		throw CompositorException("shader is not initialized");
+		printf("shader is not initialized\n");
+		abort();
 	}
 
 	glUniform1i(glGetUniformLocation(_program, name), value);
@@ -81,7 +87,8 @@ void Shader::set_uniform(const char* name, int value)
 void Shader::set_uniform(const char* name, float value[4])
 {
 	if(_program == 0){
-		throw CompositorException("shader is not initialized");
+		printf("shader is not initialized\n");
+		abort();
 	}
 
 	glUniform4f(glGetUniformLocation(_program, name), value[0], value[1], value[2], value[3]);
@@ -90,7 +97,8 @@ void Shader::set_uniform(const char* name, float value[4])
 void Shader::set_uniform_mat(const char* name, float value[])
 {
 	if(_program == 0){
-		throw CompositorException("shader is not initialized");
+		printf("shader is not initialized\n");
+		abort();
 	}
 
 	glUniformMatrix4fv(glGetUniformLocation(_program, name), 1, false, value);

--- a/lib/renderer/src/renderer/visualbackend/rust/RustVisualBackend.cpp
+++ b/lib/renderer/src/renderer/visualbackend/rust/RustVisualBackend.cpp
@@ -16,9 +16,12 @@ RustVisualBackend::RustVisualBackend(int32_t width, int32_t height)
 {
 	std::cout << "RustVisualBackend::RustVisualBackend" << std::endl;
 
+#ifndef EMSCRIPTEN
 	if(rv_api_1 != 1){
-		throw RendererException("Invalid libvangers_ffi version");
+		printf("Invalid librusty_vangers version expected 1, actual %d\n", rv_api_1);
+		abort();
 	}
+#endif
 
 	rv_init_descriptor desc {
 		.width = (uint32_t) width,
@@ -46,8 +49,8 @@ void RustVisualBackend::camera_create(const CameraDescription& camera_descriptio
 	rv_camera_description v_desc {
 		.fov = camera_description.fov,
 		.aspect = camera_description.aspect,
-        .near= camera_description.near_plane,
-        .far = camera_description.far_plane,
+		.near= camera_description.near_plane,
+		.far = camera_description.far_plane,
 	};
 
 	std::cout << "rv_camera_init(context=" << _context << ", {" << std::endl
@@ -167,16 +170,16 @@ void RustVisualBackend::map_update_palette(uint32_t* palette, int32_t palette_si
 void RustVisualBackend::set_screen_resolution(int32_t width, int32_t height)
 {
 	std::cout << "RustVisualBackend::set_screen_resolution" <<
-	             " width: " << width <<
-	             " , height: "<< height <<
-	             std::endl;
+				 " width: " << width <<
+				 " , height: "<< height <<
+				 std::endl;
 
 	uint32_t rv_width = width;
 	uint32_t rv_height = height;
 	std::cout << "rv_resize(context=" << _context <<
-	             ", width="<<rv_width <<
-	             ", height="<<rv_height <<
-	             ")" << std::endl;
+				 ", width="<<rv_width <<
+				 ", height="<<rv_height <<
+				 ")" << std::endl;
 	rv_resize(_context, rv_width, rv_height);
 }
 

--- a/lib/xgraph/xgraph.cpp
+++ b/lib/xgraph/xgraph.cpp
@@ -132,7 +132,7 @@ int XGR_Screen::init(int x,int y,int flags_in)
 	std::cout<<"XGR_Screen::init"<<std::endl;
 	// Init SDL video
 	if (XGR_ScreenSurface==NULL) {
-		if (SDL_Init(SDL_INIT_EVERYTHING) < 0) {
+		if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER) < 1) {
 			auto* error = SDL_GetError();
 
 			std::cerr << "SDL_Init failed: "<<error<<std::endl;
@@ -183,7 +183,7 @@ int XGR_Screen::init(int x,int y,int flags_in)
 		std::cout<<"Can't load icon vangers.bmp"<<std::endl;
 	}
 
-    renderer = new renderer::compositor::gles3::GLES3Compositor(x, y, (GLADloadproc)SDL_GL_GetProcAddress);
+	renderer = new renderer::compositor::gles3::GLES3Compositor(x, y, (GLADloadproc)SDL_GL_GetProcAddress);
 	renderer->initialize();
 	// TODO:
 	std::cout<<"SDL_SetRenderDrawColor"<<std::endl;


### PR DESCRIPTION
1. throw is removed because try/catch is not used, and it helps to keep web binary as small as possible
2. rv_api_1 can't be linked using this style for now, so disabled for emscripten