### PR TITLE
Minimap holes fix: drawing a background filled with ones

### DIFF
--- a/src/actint/actint.cpp
+++ b/src/actint/actint.cpp
@@ -4003,15 +4003,6 @@ void actIntDispatcher::init(void)
 	if(wMap -> world_ids[CurrentWorld] != -1 && map_names[wMap -> world_ids[CurrentWorld]]){
 		mapObj -> free();
 		mapObj -> load(map_names[wMap -> world_ids[CurrentWorld]],1);
-		// TODO: the code below is quick hack
-		//  for blitting XGR_Obj 2d surface onto main, with color=0 as colorkey
-		//  This should be solved in the future with actIntDispatcher refactoring
-		int size = mapObj->Size * mapObj->SizeX * mapObj->SizeY;
-		for (int i = 0; i < size; ++i) {
-			if(mapObj->frames[i] == 0){
-				mapObj->frames[i] = 1; // Should be a close to black color
-			}
-		}
 	}
 	else {
 		ErrH.Abort("Map BMP not found...");

--- a/src/actint/ascr_fnc.cpp
+++ b/src/actint/ascr_fnc.cpp
@@ -1296,6 +1296,9 @@ void show_map(int x,int y,int sx,int sy)
 	if(y0 < 0) y0 += p -> SizeY;
 	if(y0 >= p -> SizeY) y0 -= p -> SizeY;
 
+	// Holes prevention: filling the back of the minimap with ones
+	XGR_Obj.erase(x, y, sx, sy, 1);
+
 	ptr = new unsigned char[sx * sy];
 	memset(ptr,0,sx * sy);
 
@@ -1393,7 +1396,9 @@ void show_map(int x,int y,int sx,int sy)
 			}
 		}
 	}
-	XGR_PutSpr(x,y,sx,sy,ptr,XGR_BLACK_FON);
+
+	// Holes prevention: overriding only non-zero pixels
+	XGR_PutSpr(x,y,sx,sy,ptr, XGR_HIDDEN_FON);
 	delete[] ptr;
 
 	_y = 0;


### PR DESCRIPTION
* Drawing a rectangle under the minimap filled with `1`. 
* Calling `XGR_PutSpr` with `XGR_HIDDEN_FON` - overriding only non-zero pixels

Fixes #390 #393 