### PR TITLE
Fix race condition durinig init coursor and bliting.

### DIFF
--- a/lib/xgraph/xgraph.cpp
+++ b/lib/xgraph/xgraph.cpp
@@ -1556,7 +1556,7 @@ XGR_Mouse::XGR_Mouse(void)
 	PromptFon = NULL;
 	promptData = NULL;
 	AlphaData = NULL;
-
+	PromptFonBufSize = 0;
 }
 
 void XGR_Mouse::Hide(void)
@@ -2263,18 +2263,13 @@ void XGR_Mouse::InitPrompt(void)
 		else
 			return;
 	}
-	if(flags & XGM_HICOLOR){
-		if(PromptFonBufSize < p -> textSizeX * p -> textSizeY * 2){
-			if(PromptFon) delete[] PromptFon;
-			PromptFonBufSize = p -> textSizeX * p -> textSizeY * 2;
-			PromptFon = new char[PromptFonBufSize];
-		}
-	}
-	else {
-		if(PromptFonBufSize < p -> textSizeX * p -> textSizeY){
-			if(PromptFon) delete[] PromptFon;
-			PromptFonBufSize = p -> textSizeX * p -> textSizeY;
-			PromptFon = new char[PromptFonBufSize];
+	int hiColorMult = flags & XGM_HICOLOR ? 2 : 1;
+	if (PromptFonBufSize < p -> textSizeX * p -> textSizeY * hiColorMult) {
+		char *oldPromptFon = PromptFon ? PromptFon : nullptr;
+		PromptFonBufSize = p -> textSizeX * p -> textSizeY * hiColorMult;
+		PromptFon = new char[PromptFonBufSize];
+		if (oldPromptFon) {
+			delete[] oldPromptFon;
 		}
 	}
 

--- a/lib/xgraph/xgraph.cpp
+++ b/lib/xgraph/xgraph.cpp
@@ -91,14 +91,24 @@ void XGR_FinitFnc(void)
 
 Uint32 CursorAnim(Uint32 interval, void *param)
 {
+	SDL_Event event;
+	SDL_zero(event);
+	event.type = SDL_USEREVENT;
+	event.user.code = CursorAnimationEvent;
+	event.user.data1 = nullptr;
+	event.user.data2 = nullptr;
+	SDL_PushEvent(&event);
+
+	return interval;
+}
+
+void doCursorAnimation() {
 	int result = 0;
 	result += XGR_MouseObj.NextFrame();
 	result += XGR_MouseObj.NextPromptFrame();
 	if(result) {
 		XGR_MouseObj.Redraw();
 	}
-
-	return interval;
 }
 
 

--- a/lib/xgraph/xgraph.h
+++ b/lib/xgraph/xgraph.h
@@ -549,6 +549,14 @@ extern int xgrScreenSizeY;
 // @caiiiycuk: deprecated, use get_default_render_buffer or get_2d_render_buffer_instead
 #define XGR_VIDEOBUF	XGR_Obj.ScreenBuf
 
+#define XGR_VIDEOBUF	XGR_Obj.ScreenBuf
+enum XGR_CustomEvents {
+	CursorAnimationEvent
+};
+
+void doCursorAnimation();
+
+
 extern XGR_Screen XGR_Obj;
 extern XGR_Mouse XGR_MouseObj;
 

--- a/lib/xgraph/xgraph_dummy.cpp
+++ b/lib/xgraph/xgraph_dummy.cpp
@@ -8,3 +8,5 @@
 bool XGR_FULL_SCREEN = false;
 void XGR_Flip() {
 }
+void doCursorAnimation() {
+}

--- a/lib/xtool/xtcore.cpp
+++ b/lib/xtool/xtcore.cpp
@@ -575,6 +575,12 @@ int xtDispatchMessage(SDL_Event* msg)
 					break;
 			}
 			break;
+		case SDL_USEREVENT:
+			switch (msg->user.code) {
+				case CursorAnimationEvent:
+					doCursorAnimation();
+			}
+			break;
 	}
 
 	return ret;

--- a/src/actint/actint.cpp
+++ b/src/actint/actint.cpp
@@ -1157,13 +1157,13 @@ void bmlObject::show(int frame)
 {
 	unsigned char* frame_ptr = frames + SizeX * SizeY * frame;
 
-	XGR_PutSpr(OffsX,OffsY,SizeX,SizeY,frame_ptr,XGR_HIDDEN_FON);
+	XGR_PutSpr(OffsX,OffsY,SizeX,SizeY,frame_ptr,XGR_HIDDEN_FON | XGR_CLIPPED);
 }
 
 void bmlObject::offs_show(int x,int y,int frame)
 {
 	unsigned char* frame_ptr = frames + SizeX * SizeY * frame;
-	XGR_PutSpr(x,y,SizeX,SizeY,frame_ptr,XGR_HIDDEN_FON);
+	XGR_PutSpr(x,y,SizeX,SizeY,frame_ptr,XGR_HIDDEN_FON | XGR_CLIPPED);
 }
 
 ibsObject::ibsObject(void)


### PR DESCRIPTION
1. It fix the race condition because our cursor rendering worked in a separate thread (now by SDL event poll). I also rewrote the function a little to be more atomic. 
2. Fixed clipping UI images that do not fit into 800x600 resolution. 