### PR TITLE
add -fsigned-char compile option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ add_compile_options(-Werror=dangling-else)
 add_compile_options(-Werror=parentheses)
 add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Werror=delete-non-virtual-dtor>)
 add_compile_options(-Werror=write-strings)
+add_compile_options(-fsigned-char)
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 	add_compile_options(-Werror=mismatched-new-delete )


### PR DESCRIPTION
У нас пердпологается что char это signed тип. Хотя спецификациями это не гарантируется, и вот как раз на андроид char unsigned. [-fsigned-char](https://gcc.gnu.org/onlinedocs/gcc-9.2.0/gcc/C-Dialect-Options.html#index-fsigned-char) гарантирует что char signed