### PR TITLE
Do not affect actual mouse position with spot point

### DIFF
--- a/lib/xgraph/xgraph.cpp
+++ b/lib/xgraph/xgraph.cpp
@@ -1656,8 +1656,8 @@ static unsigned short XGR_MouseDefFrameHC[240] =
 
 void XGR_Mouse::Init(int x,int y,int sx,int sy,int num,void* p)
 {
-	PosX = x;
-	PosY = y;
+	PosX = x - SpotX;
+	PosY = y - SpotX;
 	SizeX = sx;
 	SizeY = sy;
 	PosZ = LastPosZ = MovementZ = 0;
@@ -1845,8 +1845,8 @@ void XGR_Mouse::InitPos(int x,int y)
 	LastSizeX = SizeX;
 	LastSizeY = SizeY;
 
-	PosX = x;
-	PosY = y;
+	PosX = x - SpotX;
+	PosY = y - SpotY;
 
 	AdjustPos();
 }
@@ -1881,10 +1881,10 @@ void XGR_Mouse::SetPos(int x,int y)
 	LastSizeX = SizeX;
 	LastSizeY = SizeY;
 
-	PosX = x;
-	PosY = y;
+	PosX = x - SpotX;
+	PosY = y - SpotY;
 
-	//AdjustPos();
+	AdjustPos();
 
 //	pt.x = PosX;
 //	pt.y = PosY;


### PR DESCRIPTION
Суть проблемы (актуально для андроид версии):
> проблема в том что сейчас ты кликаешь в точку [0, 0] из за спота игра воспринимает её как [5, 5] допустим. в ПК версии ты не замечаешь этого потому что ты не видишь системный курсор. а если его включить у тебя будет не понимание почему ты кликнул четко в кнопку, а она не сработала (из-за смещения). должно быть наоборот, не нужно смещать координаты нажатия, нужно что бы при рисовании сам курсор смещался. т.е. ты кликнул в [0,0], а курсор отрисовался в [-5, -5], но клик прошёл в игру как [0,0]. вот эим сейчас занимаюсь

Что бы не трогать код рисования, я просто смещаю PosX, PosY на величину спота, а в клик хендлерах она как раз прибавляется к PosX, PosY по этому фактически игра воспринимает реальное положение мышки, а не смещенное.