### PR TITLE
chat fixes

### DIFF
--- a/src/iscreen/i_chat.cpp
+++ b/src/iscreen/i_chat.cpp
@@ -488,6 +488,7 @@ void iChatInit(void)
 
 	iChatHistory = new iChatHistoryScreen;
 	iChatHistory -> init(x,y + (ICS_BUTTON_SIZE_Y + ICS_DELTA) * 1,ICS_HISTORY_SIZE_X,ICS_HISTORY_SIZE_Y,bcol,bcol);
+	iChatHistory -> position = std::max(0, message_dispatcher.ListSize - ICS_HISTORY_MAX_MESSAGES);
 
 	iChatInput = new iChatInputField;
 	iChatInput -> init(x,y + ICS_HISTORY_SIZE_Y + ICS_DELTA + (ICS_BUTTON_SIZE_Y + ICS_DELTA) * 1,ICS_HISTORY_SIZE_X,ICS_BUTTON_SIZE_Y,bcol,bcol);

--- a/src/iscreen/i_chat.cpp
+++ b/src/iscreen/i_chat.cpp
@@ -468,8 +468,8 @@ void iChatInit(void)
 	int x,y,sx,sy,bsx,col0,col1,bcol;
 	iChatButton* p;
 
-	sx = ICS_HISTORY_SIZE_X + ICS_DELTA + ICS_BUTTON_SIZE_X + (XGR_MAXX - 800);
-	sy = ICS_HISTORY_SIZE_Y + ICS_DELTA * 2 + ICS_BUTTON_SIZE_Y * 2 + (XGR_MAXY - 600);
+	sx = ICS_HISTORY_SIZE_X + ICS_DELTA + ICS_BUTTON_SIZE_X;
+	sy = ICS_HISTORY_SIZE_Y + ICS_DELTA * 2 + ICS_BUTTON_SIZE_Y * 2;
 
 //	  bsx = (sx - ICS_DELTA * 2) / 3;
 	bsx = (ICS_HISTORY_SIZE_X - ICS_DELTA * 2) / 3;
@@ -481,6 +481,8 @@ void iChatInit(void)
 		bcol = ICS_BORDER_COLOR;
 	else {
 		y -= 30;
+		x -= (XGR_MAXX - 800) / 2;
+		y -= (XGR_MAXY - 600) / 2;
 		bcol = ICS_iBORDER_COLOR;
 	}
 


### PR DESCRIPTION
- set history position at end instead of start
before the commit there were the oldest messages instead of the newest ones when opening the chat

- centered chat in hd