### PR TITLE
Fix middle height computation in 3D dynamics

### DIFF
--- a/src/3d/dynamics.cpp
+++ b/src/3d/dynamics.cpp
@@ -956,7 +956,7 @@ inline int get_three_heights(int x,int y)
 		return *p;
 	//64 bit problem
 	uintptr_t ll = *LOW_LEVEL(p);
-	return ll | (ll + (GET_THICKNESS(p) << 8)) | ((uintptr_t)(*HIGH_LEVEL(p)) << 16) | 0xff000000;
+	return ll | ((ll + GET_THICKNESS(p)) << 8) | ((uintptr_t)(*HIGH_LEVEL(p)) << 16) | 0xff000000;
 }
 inline int get_upper_height(int x,int y)
 {


### PR DESCRIPTION
The semantics (and usage) of the function is such that it returns 4 bytes: lower height, middle height, upper height, and 0xFF. I believe the brackets "(" and ")" were accidentally put in the wrong place here for the middle term.