### PR TITLE
Client net protocol version updated; server now handles protocol versions differently; multiplayer world activity cycles fixed

### DIFF
--- a/server/server.cpp
+++ b/server/server.cpp
@@ -1216,7 +1216,7 @@ int Player::receive() {
 			IN_EVENTS_LOG(ATTACH_TO_GAME);
 
 			if (this->client_version > 1) {
-				long int t = 0;
+				time_t t = 0;
 				time(&t);
 				out_buffer.begin_event(zTIME_RESPONSE);
 				out_buffer < (unsigned int)t;

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -20,8 +20,8 @@ extern XStream fout;
 extern int frame;
 extern int GlobalExit;
 
-#define CLIENT_VERSION	1
-#define SERVER_VERSION	1
+#define CLIENT_VERSION	2
+#define SERVER_VERSION	2
 
 //zmod
 int zserver_version = 0;
@@ -273,7 +273,6 @@ int identification(XSocket& socket)
 		 //   return 0;
 		}
 	}
-
 // /zMod ---------------------------------------------------------
 
 	return 1;
@@ -812,10 +811,9 @@ int connect_to_server(ServerFindChain* p)
 		events_in.ignore_event();
 
 		zGameBirthTime = 0;
-		if (zserver_version > 1) {
-			//std::cout<<"zTIME_RESPONSE"<<std::endl;
-			events_in.receive_waiting_for_event(zTIME_RESPONSE); //ZMOD second network packet
-			//std::cout<<"[ok]"<<std::endl;
+		if (zserver_version > 1 || SERVER_VERSION > 1) {
+			// zMod second network packet, used as a seed for world activity cycles
+			events_in.receive_waiting_for_event(zTIME_RESPONSE);
 			zGameBirthTime = events_in.get_int();
 			events_in.ignore_event();
 		}


### PR DESCRIPTION
Since the release of multiplayer in open source version the multiplayer-only cyclic activity of worlds was enabled, but clients were not receiving expected seed – game "birth date", which lead to this activity being permanently stuck in the same state: Weexow was flooded, Necross was more dry & insects there were more aggresive etc.

Changes introduced in the commit:

- Client-side protocol version is now 2 (was 1)
- Server-side constant for protocol version now replaced with two constants which indicate the minimal and maximal supported protocol versions (instead of forcing one specific version); they are used for specifying protocol version for games (otherwise games on the new server wouldn't be visible to old clients) and player attachment
- Also server-side: if specific client's protocol version is > 1, then an additional net packet is sent (like it was for the old multiplayer zMod client) with seed/"birth date" value for initializing cyclic world activity

Tested cases:

- New clients can connect to a new server and create new games or join games created by any (old or new) clients; they'll see fixed world activity
- Old clients can do the same while experiencing no issues, though without seeing activity fix
- New clients won't be able to connect to old servers – at the moment there's only one active server that needs to be updated and two other working, but not really used servers, so this shouldn't be an issue

Meaning the issue is fixed and backwards compatibility for old clients is intact as well.