### PR TITLE
Fix #158: incorrect flooding for initial portion of world player sees first

### DIFF
--- a/src/terra/vmap.cpp
+++ b/src/terra/vmap.cpp
@@ -1136,6 +1136,27 @@ void vrtMap::accept(int up,int down)
 				ExpandBuffer(inbuf,p);
 			}
 
+			//ZMOD 1.18 DYNAMIC WATER (there is one more in lower)
+			//ZMOD 1.20 fix
+			if (NetworkON && zMod_flood_level_delta!=0) {
+				uchar* pa,*pc,*pf,*pa0,*pc0,*pf0;
+				uchar type,lxVal,rxVal;
+				pa0 = pa = p;
+				pf0 = pf = pa0 + H_SIZE;
+
+				if (zMod_flood_level_delta>0) { //если уровень повысился
+					for(int x = 0;x < H_SIZE; x++, pa++, pf++)
+						if (*(pa0 + x) <= FloodLEVEL) //заливаем все что ниже уровня
+							*pf &= ~TERRAIN_MASK & ~OBJSHADOW; 
+
+				} else { //если уровень понизился
+					for(int x = 0;x < H_SIZE; x++, pa++, pf++)
+						if (*(pa0 + x) > FloodLEVEL) //осушаем все что выше уровня 
+							if(GET_TERRAIN(*pf) == WATER_TERRAIN_INDEX) //и только существующую воду
+								*pf |= MAIN_TERRAIN;
+				}
+			}
+
 			lineT[i] = p; //znfo lineT compressed //загрузка
 			lineTcolor[i] = use_c();
 #endif
@@ -1513,27 +1534,26 @@ void vrtMap::linkC(int up,int down,int d)
 				ExpandBuffer(inbuf,p);
 			}
 
-//ZMOD 1.18 DYNAMIC WATER (there is one more in upper)
-//ZMOD 1.20 fix
-if (NetworkON && zMod_flood_level_delta!=0) {
-	uchar* pa,*pc,*pf,*pa0,*pc0,*pf0;
-	uchar type,lxVal,rxVal;
-	pa0 = pa = p;
-	pf0 = pf = pa0 + H_SIZE;
+			//ZMOD 1.18 DYNAMIC WATER (there is one more in upper)
+			//ZMOD 1.20 fix
+			if (NetworkON && zMod_flood_level_delta!=0) {
+				uchar* pa,*pc,*pf,*pa0,*pc0,*pf0;
+				uchar type,lxVal,rxVal;
+				pa0 = pa = p;
+				pf0 = pf = pa0 + H_SIZE;
 
-	if (zMod_flood_level_delta>0) { //если уровень повысился
-		for(int x = 0;x < H_SIZE; x++, pa++, pf++)
-			if (*(pa0 + x) <= FloodLEVEL) //заливаем все что ниже уровня
-				*pf &= ~TERRAIN_MASK & ~OBJSHADOW; 
+				if (zMod_flood_level_delta>0) { //если уровень повысился
+					for(int x = 0;x < H_SIZE; x++, pa++, pf++)
+						if (*(pa0 + x) <= FloodLEVEL) //заливаем все что ниже уровня
+							*pf &= ~TERRAIN_MASK & ~OBJSHADOW; 
 	
-	} else { //если уровень понизился
-		for(int x = 0;x < H_SIZE; x++, pa++, pf++)
-			if (*(pa0 + x) > FloodLEVEL) //осушаем все что выше уровня 
-				if(GET_TERRAIN(*pf) == WATER_TERRAIN_INDEX) //и только существующую воду
-					*pf |= MAIN_TERRAIN;
-
-	}
-}
+				} else { //если уровень понизился
+					for(int x = 0;x < H_SIZE; x++, pa++, pf++)
+						if (*(pa0 + x) > FloodLEVEL) //осушаем все что выше уровня 
+							if(GET_TERRAIN(*pf) == WATER_TERRAIN_INDEX) //и только существующую воду
+								*pf |= MAIN_TERRAIN;
+				}
+			}
 
 /*
 	//znfo ficha DRY (there is one more in upper)

--- a/src/terra/vmap.cpp
+++ b/src/terra/vmap.cpp
@@ -1082,6 +1082,38 @@ void vrtMap::dump_terrain() {
 	//delete[] line_buffer;
 }
 
+void vrtMap::netModify(uchar* p) {
+	//ZMOD 1.18 DYNAMIC WATER
+	//ZMOD 1.20 fix
+	if (NetworkON && zMod_flood_level_delta!=0) {
+		uchar* pa,*pc,*pf,*pa0,*pc0,*pf0;
+		//uchar type,lxVal,rxVal;
+		pa0 = pa = p;
+		pf0 = pf = pa0 + H_SIZE;
+
+		if (zMod_flood_level_delta>0) { //если уровень повысился
+			for(int x = 0;x < H_SIZE; x++, pa++, pf++)
+				if (*(pa0 + x) <= FloodLEVEL) //заливаем всё что ниже уровня
+					*pf &= ~TERRAIN_MASK & ~OBJSHADOW;
+
+		} else { //если уровень понизился
+			for(int x = 0;x < H_SIZE; x++, pa++, pf++)
+				if (*(pa0 + x) > FloodLEVEL) //осушаем всё что выше уровня
+					if(GET_TERRAIN(*pf) == WATER_TERRAIN_INDEX) //и только существующую воду
+						*pf |= MAIN_TERRAIN;
+		}
+	}
+	/*
+	//znfo ficha DRY
+	uchar* pf = p + H_SIZE;
+	for (int x=0;x<H_SIZE; x++,pf++) {
+		if(GET_TERRAIN(*pf) == WATER_TERRAIN_INDEX) {
+			*pf |= MAIN_TERRAIN_INDEX << TERRAIN_OFFSET;
+			}
+		}
+	*/
+}
+
 /*Функция загрузки карт высот и т.д.
 Удалил закомментированный код, смотреть в svn.*/
 void vrtMap::accept(int up,int down) 
@@ -1136,26 +1168,7 @@ void vrtMap::accept(int up,int down)
 				ExpandBuffer(inbuf,p);
 			}
 
-			//ZMOD 1.18 DYNAMIC WATER (there is one more in lower)
-			//ZMOD 1.20 fix
-			if (NetworkON && zMod_flood_level_delta!=0) {
-				uchar* pa,*pc,*pf,*pa0,*pc0,*pf0;
-				uchar type,lxVal,rxVal;
-				pa0 = pa = p;
-				pf0 = pf = pa0 + H_SIZE;
-
-				if (zMod_flood_level_delta>0) { //если уровень повысился
-					for(int x = 0;x < H_SIZE; x++, pa++, pf++)
-						if (*(pa0 + x) <= FloodLEVEL) //заливаем все что ниже уровня
-							*pf &= ~TERRAIN_MASK & ~OBJSHADOW; 
-
-				} else { //если уровень понизился
-					for(int x = 0;x < H_SIZE; x++, pa++, pf++)
-						if (*(pa0 + x) > FloodLEVEL) //осушаем все что выше уровня 
-							if(GET_TERRAIN(*pf) == WATER_TERRAIN_INDEX) //и только существующую воду
-								*pf |= MAIN_TERRAIN;
-				}
-			}
+			netModify(p);
 
 			lineT[i] = p; //znfo lineT compressed //загрузка
 			lineTcolor[i] = use_c();
@@ -1534,36 +1547,7 @@ void vrtMap::linkC(int up,int down,int d)
 				ExpandBuffer(inbuf,p);
 			}
 
-			//ZMOD 1.18 DYNAMIC WATER (there is one more in upper)
-			//ZMOD 1.20 fix
-			if (NetworkON && zMod_flood_level_delta!=0) {
-				uchar* pa,*pc,*pf,*pa0,*pc0,*pf0;
-				uchar type,lxVal,rxVal;
-				pa0 = pa = p;
-				pf0 = pf = pa0 + H_SIZE;
-
-				if (zMod_flood_level_delta>0) { //если уровень повысился
-					for(int x = 0;x < H_SIZE; x++, pa++, pf++)
-						if (*(pa0 + x) <= FloodLEVEL) //заливаем все что ниже уровня
-							*pf &= ~TERRAIN_MASK & ~OBJSHADOW; 
-	
-				} else { //если уровень понизился
-					for(int x = 0;x < H_SIZE; x++, pa++, pf++)
-						if (*(pa0 + x) > FloodLEVEL) //осушаем все что выше уровня 
-							if(GET_TERRAIN(*pf) == WATER_TERRAIN_INDEX) //и только существующую воду
-								*pf |= MAIN_TERRAIN;
-				}
-			}
-
-/*
-	//znfo ficha DRY (there is one more in upper)
-	uchar* pf = p + H_SIZE;
-	for (int x=0;x<H_SIZE; x++,pf++) {
-		if(GET_TERRAIN(*pf) == WATER_TERRAIN_INDEX) {
-			*pf |= MAIN_TERRAIN_INDEX << TERRAIN_OFFSET;
-			}
-		}
-*/
+			netModify(p);
 
 			lineT[i] = p; //znfo lineT compressed //догрузка
 			lineTcolor[i] = use_c();

--- a/src/terra/vmap.h
+++ b/src/terra/vmap.h
@@ -76,6 +76,7 @@ struct vrtMap {
 	void allocHeap(void);
 	void lockHeap(void);
 	void dump_terrain(void);
+	void netModify(uchar* p);
 	void accept(int up,int down);
 	void change(int up,int down);
 	void request(int up,int down,int left, int right);


### PR DESCRIPTION
Somehow a portion of zMod code was missing from `vrtMap::accept`, even though similar logic was in `vrtMap::linkC`, as it should've been, including a comment hinting at the fact that something similar should've been somewhere above.

This resulted in incorrect water levels on a portion of world that is drawn when player appears in the world (from escave or Passage), and player only needed to move far away enough from that portion and go back – and voila, it would've rendered correctly.

Still the issue was affecting gameplay – it was not purely visual, the water really appeared and disappeared as player moved around, I've described one such gameplay change example below for anyone interested.

I.e. when entering Weexow in multiplayer (which is stuck in permanent flood due to issue, which is fixed by #619 ) player sees the normal area, but water around them was in fact much higher than the land, even though this isn't immediately obvious. This leads to local exploding "fish" being able to jump onto player from above (as they always float on top of water) easily destroying weaker mechoses; also confusing is the scenario when player goes to the artifact island here and returns to see the Passage island being flooded (whereas it was just redrawn properly). After this fix player will properly see the flooded island right from the start and fish wouldn't be able to harm them, because they're floating far above the player (unless the player tries to jump above).