### PR TITLE
Skip 'H' in background files if XGR_HIDDEN_FON is set

### DIFF
--- a/lib/xgraph/xgraph.cpp
+++ b/lib/xgraph/xgraph.cpp
@@ -447,7 +447,9 @@ void XGR_Screen::putspr(int x,int y,int sx,int sy,void* p,int mode)
 		for(i = 0; i < _sy; i ++){
 			for(j = 0; j < _sx; j ++){
 				if(memBuf[j]){
-					scrBuf[j] = memBuf[j];
+					if ((mode & XGR_HIDDEN_FON) == 0 || memBuf[j] != 'H') {
+						scrBuf[j] = memBuf[j];
+					}
 				}
 			}
 			scrBuf += yStrOffs;


### PR DESCRIPTION
Background file `resource/actint/800x600/screens/b600.bmp`
uses 'H' (72) to indicate background color.

When background is rendered to 2D buffer,
this "color" should be skipped to avoid shadowing
default buffer which is used to render the map.

Fixes #639