### PR TITLE
Fixed oxygen bar offset

### DIFF
--- a/src/road.cpp
+++ b/src/road.cpp
@@ -967,7 +967,7 @@ _MEM_STATISTIC_("AFTER TABLE OPEN  -> ");
 		COMPAS_RIGHT = DEFAULT_COMPAS_RIGHT;
 	} else {
 		curGMap = new iGameMap(XGR_MAXX / 2, XGR_MAXY / 2, XGR_MAXX / 2, XGR_MAXY / 2);
-		COMPAS_RIGHT = HD_COMPAS_RIGHT;
+		COMPAS_RIGHT = DEFAULT_COMPAS_RIGHT;
 	}
 #else
 	curGMap = new iGameMap(XGR_MAXX/2,XGR_MAXY/2,XSIDE,YSIDE);
@@ -1697,6 +1697,10 @@ iGameMap::iGameMap(int _x,int _y,int _xside,int _yside)
 	UcutRight = xc + xside;
 	VcutUp = yc - yside;
 	VcutDown = yc + yside;
+	
+	if (XGR_Obj.get_screen_scale_x() == 1.6f) {
+		UcutRight = (XGR_MAXX - (800 - aScrDisp -> curIbs -> SizeX));
+	}
 
 //	  focus = (xside*540)/180;
 	focus_flt = focus = 512;
@@ -1756,6 +1760,10 @@ void iGameMap::change(int Dx,int Dy,int mode,int xcenter,int ycenter)
 	UcutRight = xc + xside;
 	VcutUp = yc - yside;
 	VcutDown = yc + yside;
+	
+	if (XGR_Obj.get_screen_scale_x() == 1.6f) {
+		UcutRight = (XGR_MAXX - (800 - aScrDisp -> curIbs -> SizeX));
+	}
 
 	TurnSecX = TurnSecX*xsize/xsize_old;
 	camera_zmin = camera_zmin*xsize/xsize_old;
@@ -2487,19 +2495,9 @@ void set_map_to_ibs(ibsObject* ibs)
 		Redraw = 1;
 
 		COMPAS_RIGHT = DEFAULT_COMPAS_RIGHT;
-	} else if (ibs->ID == 2 /* INVENTORY HD*/) {
-		auto inventoryWidth = 800 - ibs->SizeX;
-			curGMap -> change(
-			(XGR_MAXX - inventoryWidth) / 2,
-			XGR_MAXY  / 2,
-			0,
-			(XGR_MAXX - inventoryWidth) / 2,
-			XGR_MAXY / 2);
-		Redraw = 1;
-		COMPAS_RIGHT = DEFAULT_COMPAS_RIGHT;
 	} else {
 		set_map_to_fullscreen();
-		COMPAS_RIGHT = HD_COMPAS_RIGHT;
+		COMPAS_RIGHT = DEFAULT_COMPAS_RIGHT;
 	}
 }
 

--- a/src/road.cpp
+++ b/src/road.cpp
@@ -964,11 +964,10 @@ _MEM_STATISTIC_("AFTER TABLE OPEN  -> ");
 #ifdef ACTINT
 	if (XGR_Obj.get_screen_scale_x() == 1) {
 		curGMap = new iGameMap(aScrDisp -> curIbs -> CenterX,aScrDisp -> curIbs -> CenterY,XSIDE,YSIDE);
-		COMPAS_RIGHT = DEFAULT_COMPAS_RIGHT;
 	} else {
 		curGMap = new iGameMap(XGR_MAXX / 2, XGR_MAXY / 2, XGR_MAXX / 2, XGR_MAXY / 2);
-		COMPAS_RIGHT = DEFAULT_COMPAS_RIGHT;
 	}
+	COMPAS_RIGHT = DEFAULT_COMPAS_RIGHT;
 #else
 	curGMap = new iGameMap(XGR_MAXX/2,XGR_MAXY/2,XSIDE,YSIDE);
 #endif
@@ -1762,7 +1761,7 @@ void iGameMap::change(int Dx,int Dy,int mode,int xcenter,int ycenter)
 	VcutDown = yc + yside;
 	
 	if (XGR_Obj.get_screen_scale_x() == 1.6f) {
-		UcutRight = (XGR_MAXX - (800 - aScrDisp -> curIbs -> SizeX));
+		UcutRight = (XGR_MAXX - (I_RES_X - aScrDisp -> curIbs -> SizeX));
 	}
 
 	TurnSecX = TurnSecX*xsize/xsize_old;
@@ -2493,11 +2492,10 @@ void set_map_to_ibs(ibsObject* ibs)
 			ibs->CenterX,
 			ibs->CenterY);
 		Redraw = 1;
-
+		
 		COMPAS_RIGHT = DEFAULT_COMPAS_RIGHT;
 	} else {
 		set_map_to_fullscreen();
-		COMPAS_RIGHT = DEFAULT_COMPAS_RIGHT;
 	}
 }
 

--- a/src/units/mechos.cpp
+++ b/src/units/mechos.cpp
@@ -8169,17 +8169,19 @@ void ActionDispatcher::DrawResource(void)
 	XGR_SetClip(UcutLeft,VcutUp,UcutRight,VcutDown);
 
 	y0 = VcutDown - RES_DRAW_DOWN;
-	x0 = UcutRight - RES_DRAW_LEFT;
+	x0 = UcutRight - RES_DRAW_RIGHT;
 	x1 = UcutLeft + RES_DRAW_LEFT;
+	
 	sx = x0 - x1;
+	int sizeX = sx * DrawResourceValue / DrawResourceMaxValue;
 
 	if(DrawResourceValue > 0){
-		XGR_Rectangle(x0 - sx * DrawResourceValue / DrawResourceMaxValue,y0,sx * DrawResourceValue / DrawResourceMaxValue,RES_DRAW_STEP_Y,228,228,XGR_FILLED);
+		XGR_Rectangle(x0 - sizeX, y0, sizeX, RES_DRAW_STEP_Y, 228, 228, XGR_FILLED);
 		DrawResourceValue = -DrawResourceValue;
 		DrawResourceTime = 130;
 	}else{
 		if(DrawResourceTime > 0){
-			XGR_Rectangle(x0 + sx * DrawResourceValue / DrawResourceMaxValue,y0,-sx * DrawResourceValue / DrawResourceMaxValue,RES_DRAW_STEP_Y,228,228,XGR_FILLED);
+			XGR_Rectangle(x0 + sizeX, y0, -sizeX, RES_DRAW_STEP_Y, 228, 228, XGR_FILLED);
 			DrawResourceTime -= 128 / 20;
 		};
 	};

--- a/src/units/mechos.h
+++ b/src/units/mechos.h
@@ -952,7 +952,8 @@ struct CompasObject
 //const int SPEETLE_AMMO = 0;
 //const int CRUSTEST_AMMO = 1;
 
-const int RES_DRAW_LEFT = 150;
+const int RES_DRAW_LEFT = 80;
+const int RES_DRAW_RIGHT = 100;
 const int RES_DRAW_DOWN = 80;
 const int RES_DRAW_STEP_Y = 10;
 const int RES_DRAW_MAX_SIZE = 300;


### PR DESCRIPTION
Поменял немного границы кислородной полоски, для hd отдельная инициализация и поведение
По факту сделал чтобы карта рисовалась как раньше, но ограничение ставилось около края интерфейса
Из-за этого немного съехал компас, пофиксил это просто использованием его стандартного варианта