### PR TITLE
Block mechos hotkeys while multiplayer chat is open

### DIFF
--- a/src/units/mechos.cpp
+++ b/src/units/mechos.cpp
@@ -68,6 +68,7 @@ extern int multi_analysis;
 extern int multi_draw;
 extern int RAM16;
 extern int GameQuantReturnValue;
+extern int aciKeyboardLocked;
 
 extern int aciWorldIndex;
 
@@ -7507,6 +7508,9 @@ extern VangerUnit *actCurrentViewObject;
 void uvsChangeCycle(void);
 
 void VangerUnit::NewKeyHandler(void) {
+	if (aciKeyboardLocked)
+		return;
+
 	Vector vCheck;
 	BulletObject *g;
 	//	VangerUnit* v;


### PR DESCRIPTION
## Summary

Fix multiplayer chat leaking gameplay hotkeys into the active mechos.

When the chat is open, it already owns keyboard input and sets `aciKeyboardLocked`. Driving controls respect that flag, but `VangerUnit::NewKeyHandler()` still polled current keyboard state every tick through `iKeyPressed()`. Because of that, typing chat characters that overlap with combat keys could fire weapon slots, all weapons, or terminators.

This PR makes `NewKeyHandler()` return while `aciKeyboardLocked` is set, using the same UI-level keyboard lock that already blocks movement input.

## Why this is the right fix

- The bug is not specific to one key: weapon slots, all-weapons fire, terminators, Vector/Gluek/open/target hotkeys all live in the same mechos hotkey path.
- Chat already explicitly marks keyboard input as UI-owned via `aciKeyboardLocked`.
- Movement already uses that same lock, so this aligns mechos gameplay hotkeys with existing input semantics instead of adding per-key special cases.

## Verification

- `cmake --build build -j2` completed successfully.
