### PR TITLE
Reset carried armor state on same-mechos purchase

### DIFF
--- a/src/actint/ascr_fnc.cpp
+++ b/src/actint/ascr_fnc.cpp
@@ -102,6 +102,7 @@ extern int GameQuantReturnValue;
 
 extern int aci_SecondMatrixID;
 extern int curMatrixID;
+extern int ChangeEnergy, ChangeArmor;
 
 extern actIntDispatcher *aScrDisp;
 
@@ -3142,6 +3143,8 @@ void aciBuyItem(void) {
 				cr = aciGetCurCredits();
 				cr -= u->price;
 				aciUpdateCurCredits(cr);
+				ChangeEnergy = -1;
+				ChangeArmor = -1;
 
 				u1 = aciGetMechos(m->type);
 				if (u1)


### PR DESCRIPTION
## Summary

- reset carried road armor/energy state immediately after a successful paid mechos purchase
- fixes buying the same mechos model in an escave preserving the damaged armor saved on escave entry
- keeps the existing `lastMechos != Pmechos->type` logic intact for real model changes/statistics

## Why

Escave exit restores `ChangeArmor`/`ChangeEnergy` so entering and leaving an escave does not repair the current mechos. The old reset only happened when the resulting mechos type changed, so buying another instance of the same type restored the old damaged armor on exit.

The fix invalidates that carried state at the semantic point where a new mechos is actually purchased, without adding session flags or changing savegame format.

## Verification

- `cmake --build build -j2`
- `clang-format --dry-run --Werror src/actint/ascr_fnc.cpp`
- `git diff --check master..HEAD`
