### PR TITLE
Fix pause menu state after multiplayer respawn

### DIFF
--- a/src/actint/ascr_fnc.cpp
+++ b/src/actint/ascr_fnc.cpp
@@ -92,6 +92,7 @@ extern unsigned char *iscrPal;
 
 extern int iScreenActive;
 extern int iSlotNumber;
+extern int iPause;
 
 extern int ShowImageKeyFlag;
 extern int ShowImageMouseFlag;
@@ -490,7 +491,7 @@ int aciLoadLog = 0;
 int aciShopMenuLog = 0;
 int aciWorldIndex = -1;
 
-int acsScreenID = 1;
+int acsScreenID = ACS_PAUSE_SCREEN1;
 
 int acsCurrentSlotID = ACS_SAVE_SLOT0;
 int acsCurrentSlotNum = 0;
@@ -2040,7 +2041,25 @@ void aci_LocationQuantPrepare(void) {
 	iKeyClear();
 }
 
+static void aciResetLocationPauseState(void) {
+	if (acsAllocFlag && acsScrD) {
+		if (!(aScrDisp->flags & AS_ISCREEN) && acsScrD->curScr) {
+			acsScrD->curScr->ChangeCoords(-(XGR_MAXX - 640) / 2, -(XGR_MAXY - 480) / 2);
+		}
+		acsScrD->free_mem();
+		acsAllocFlag = 0;
+	}
+
+	iPause = 0;
+	if (NetworkON)
+		aciKeyboardLocked = 0;
+	acsScreenID = ACS_PAUSE_SCREEN1;
+	if (KeyBuf)
+		KeyBuf->clear();
+}
+
 void aci_LocationQuantFinit(void) {
+	aciResetLocationPauseState();
 	iScrQuantFinit();
 	aScrDisp->i_finit();
 	aciKillLinks();
@@ -5273,7 +5292,7 @@ int acsQuant(void) {
 		if (NetworkON)
 			aciKeyboardLocked = 0;
 
-		acsScreenID = 1;
+		acsScreenID = ACS_PAUSE_SCREEN1;
 		iSaveData();
 		KeyBuf->clear();
 		return 1;

--- a/src/actint/ascr_fnc.cpp
+++ b/src/actint/ascr_fnc.cpp
@@ -2041,14 +2041,38 @@ void aci_LocationQuantPrepare(void) {
 	iKeyClear();
 }
 
-static void aciResetLocationPauseState(void) {
-	if (acsAllocFlag && acsScrD) {
-		if (!(aScrDisp->flags & AS_ISCREEN) && acsScrD->curScr) {
-			acsScrD->curScr->ChangeCoords(-(XGR_MAXX - 640) / 2, -(XGR_MAXY - 480) / 2);
-		}
-		acsScrD->free_mem();
-		acsAllocFlag = 0;
+static void aciFinishPauseScreen(void) {
+	if (!acsAllocFlag || !acsScrD)
+		return;
+
+	acsAllocFlag = 0;
+	if (!(aScrDisp->flags & AS_ISCREEN) && acsScrD->curScr) {
+		acsScrD->curScr->ChangeCoords(-(XGR_MAXX - 640) / 2, -(XGR_MAXY - 480) / 2);
 	}
+	acsScrD->free_mem();
+	if (aScrDisp->flags & AS_FULLSCR && !(aScrDisp->flags & AS_ISCREEN)) {
+		XGR_MouseHide();
+	} else
+		aScrDisp->flags &= ~AS_FULL_REDRAW;
+
+	iScrDisp->flags &= ~MS_LEFT_PRESS;
+	iScrDisp->flags &= ~MS_RIGHT_PRESS;
+	iScrDisp->flags &= ~MS_MOVED;
+	iHandleExtEvent(iEXT_UPDATE_TUTORIAL_MODE);
+	iHandleExtEvent(iEXT_UPDATE_SOUND_MODE);
+	iHandleExtEvent(iEXT_UPDATE_SOUND_VOLUME);
+
+	if (NetworkON)
+		aciKeyboardLocked = 0;
+
+	acsScreenID = ACS_PAUSE_SCREEN1;
+	iSaveData();
+	if (KeyBuf)
+		KeyBuf->clear();
+}
+
+static void aciResetLocationPauseState(void) {
+	aciFinishPauseScreen();
 
 	iPause = 0;
 	if (NetworkON)
@@ -5272,29 +5296,7 @@ int acsQuant(void) {
 		acsScrD->PrepareInput(acsCurrentSlotID);
 	}
 	if (ret) {
-		acsAllocFlag = 0;
-		if (!(aScrDisp->flags & AS_ISCREEN)) {
-			acsScrD->curScr->ChangeCoords(-(XGR_MAXX - 640) / 2, -(XGR_MAXY - 480) / 2);
-		}
-		acsScrD->free_mem();
-		if (aScrDisp->flags & AS_FULLSCR && !(aScrDisp->flags & AS_ISCREEN)) {
-			XGR_MouseHide();
-		} else
-			aScrDisp->flags &= ~AS_FULL_REDRAW;
-
-		iScrDisp->flags &= ~MS_LEFT_PRESS;
-		iScrDisp->flags &= ~MS_RIGHT_PRESS;
-		iScrDisp->flags &= ~MS_MOVED;
-		iHandleExtEvent(iEXT_UPDATE_TUTORIAL_MODE);
-		iHandleExtEvent(iEXT_UPDATE_SOUND_MODE);
-		iHandleExtEvent(iEXT_UPDATE_SOUND_VOLUME);
-
-		if (NetworkON)
-			aciKeyboardLocked = 0;
-
-		acsScreenID = ACS_PAUSE_SCREEN1;
-		iSaveData();
-		KeyBuf->clear();
+		aciFinishPauseScreen();
 		return 1;
 	}
 	return 0;

--- a/src/iscreen/iscr_fnc.cpp
+++ b/src/iscreen/iscr_fnc.cpp
@@ -810,8 +810,10 @@ int iQuantSecond(void) {
 						iChatKeyQuant(k);
 					if ((k->type == SDL_KEYDOWN && k->key.keysym.scancode == SDL_SCANCODE_ESCAPE) &&
 						actIntLog) {
+						if (!iPause)
+							ipal_iter(iScreenOffs);
 						iPause ^= 1;
-						acsScreenID = 2;
+						acsScreenID = ACS_PAUSE_SCREEN2;
 						if (iPause) {
 							XGR_Obj.fill(0, XGR_Obj.get_2d_render_buffer());
 							XGR_Obj.fill(0, XGR_Obj.get_2d_rgba_render_buffer());

--- a/src/road.cpp
+++ b/src/road.cpp
@@ -69,6 +69,7 @@ void reconfigure_runtime_fps_scaled_state(double old_coeff, double new_coeff);
 #	include "iscreen/controls.h"
 #	include "iscreen/i_chat.h"
 #	include "actint/actint.h"
+#	include "actint/acsconst.h"
 #endif
 
 #include "palette.h"
@@ -122,6 +123,7 @@ extern int SoundVolumePanning;
 
 #ifdef ACTINT
 extern int aciLoadLog;
+extern int acsScreenID;
 extern actIntDispatcher *aScrDisp;
 #endif
 
@@ -1591,6 +1593,9 @@ void KeyCenter(SDL_Event *key) {
 #endif
 		std::cout << "road.KeyCenter:" << key << std::endl;
 		if (!Pause) {
+#ifdef ACTINT
+			acsScreenID = ACS_PAUSE_SCREEN1;
+#endif
 			Pause = 1;
 		}
 


### PR DESCRIPTION
## Problem

In multiplayer the simulation can keep running while the window is inactive. If the player dies while Alt-Tabbed and is moved through the escave/respawn flow, opening pause afterwards could reuse stale ACS pause state from the previous road/iscreen context.

Observed symptoms:

- in escave/shop pause, the pause overlay could be drawn with the wrong palette;
- on the road, the pause overlay could use the wrong screen/layout state and render text in the wrong position.

## Solution

Make pause context boundaries explicit instead of relying on the previous global `acsScreenID` / palette state:

- road pause now explicitly selects `ACS_PAUSE_SCREEN1` before opening;
- escave/shop pause explicitly uses `ACS_PAUSE_SCREEN2`;
- before opening escave/shop pause, the current location palette is applied through the same `ipal_iter(...)` path used by normal non-paused iscreen quant;
- when leaving a location, any unfinished pause/ACS state is reset:
  - allocated ACS pause screen memory is freed if needed;
  - `iPause` is cleared;
  - network keyboard lock is released;
  - queued keys are cleared;
  - default pause screen is reset to `ACS_PAUSE_SCREEN1`.

This does not change resources, Alt-Tab handling, multiplayer flow, or pause UI assets. It only prevents stale global pause state from leaking between road and iscreen contexts.

## Validation

- `cmake --build build -j2`
