### PR TITLE
Limit remote spheroid activation sounds

### DIFF
--- a/src/units/items.cpp
+++ b/src/units/items.cpp
@@ -84,7 +84,8 @@ static int should_play_spheroid_activation_sound(VangerUnit *owner) {
 		return 1;
 	if (owner == ActD.Active)
 		return 1;
-	return owner->ExternalDraw;
+	return owner->Visibility == VISIBLE && owner->ExternalDraw &&
+		   !(owner->Status & SOBJ_WAIT_CONFIRMATION);
 }
 
 static void NetworkLogStuffObject(const char *tag, StuffObject *p, const char *extra) {

--- a/src/units/items.cpp
+++ b/src/units/items.cpp
@@ -77,6 +77,16 @@ static int CheckLiveVangerPointer(VangerUnit *p) {
 	return 0;
 };
 
+static int should_play_spheroid_activation_sound(VangerUnit *owner) {
+	if (!ActD.Active || !owner)
+		return 0;
+	if (!NetworkON)
+		return 1;
+	if (owner == ActD.Active)
+		return 1;
+	return owner->ExternalDraw;
+}
+
 static void NetworkLogStuffObject(const char *tag, StuffObject *p, const char *extra) {
 	if (!p)
 		return;
@@ -1167,12 +1177,12 @@ void GunDevice::DeviceIn(void) {
 		switch (ActIntBuffer.type) {
 		case ACI_AMPUTATOR:
 			EffD.CreateDeform(Owner->R_curr, DEFORM_ALL, PASSING_WAVE_PROCESS);
-			if (ActD.Active)
+			if (should_play_spheroid_activation_sound(Owner))
 				SOUND_AMPUTATOR_SHOT(getDistX(ActD.Active->R_curr.x, Owner->R_curr.x));
 			break;
 		case ACI_DEGRADATOR:
 			EffD.CreateDeform(Owner->R_curr, DEFORM_ALL, PASSING_WAVE_PROCESS);
-			if (ActD.Active)
+			if (should_play_spheroid_activation_sound(Owner))
 				SOUND_DEGRADATOR_SHOT(getDistX(ActD.Active->R_curr.x, Owner->R_curr.x));
 			break;
 		case ACI_MECHOSCOPE:


### PR DESCRIPTION
## Problem

In multiplayer, activating an already charged Amputator or Degradator could be heard by every player in the same world, regardless of distance from the source.

The issue is specific to the activation sound that happens when a player picks up an active spheroid and it immediately triggers. The launch/fire sound already follows the normal remote weapon visibility path.

Root cause:

- remote item ownership/state updates run `GunDevice::DeviceIn()` on receiving clients;
- `GunDevice::DeviceIn()` played `SOUND_AMPUTATOR_SHOT` / `SOUND_DEGRADATOR_SHOT` whenever `ActD.Active` existed;
- the current sound wrapper uses the passed distance as stereo panning only, not as distance attenuation;
- therefore a remote activation anywhere in the world was played at full audible volume.

## Solution

Add a small local audibility helper for spheroid activation sounds:

- single-player keeps the old behavior;
- the local multiplayer player always hears their own activation;
- remote multiplayer activations are played only when the owner is externally drawn/visible for this client.

This mirrors the existing remote weapon fire semantics in `GunSlot::RemoteFire()`, where remote sounds are not played for owners that are not externally drawn.

## Scope

This PR intentionally does not change:

- multiplayer protocol;
- server behavior;
- sound resources;
- the generic sound engine;
- Terminator launch/fire sounds;
- Incarnator behavior.

Incarnator is left unchanged because the `NetworkON` branch of this code path does not play an activation sound here.

## Validation

- `cmake --build build -j2`
