### PR TITLE
Ignore hidden files during resource discovery

### DIFF
--- a/src/file_utils.h
+++ b/src/file_utils.h
@@ -1,0 +1,28 @@
+#ifndef VANGERS_FILE_UTILS_H
+#define VANGERS_FILE_UTILS_H
+
+#include <cstring>
+
+namespace vangers::files {
+
+inline bool is_visible_directory_entry(const char *name) {
+	return name && name[0] && name[0] != '.';
+}
+
+inline bool has_exact_extension(const char *name, const char *extension) {
+	if (!name || !extension)
+		return false;
+
+	const std::size_t name_length = std::strlen(name);
+	const std::size_t extension_length = std::strlen(extension);
+	return extension_length <= name_length &&
+		   std::strcmp(name + name_length - extension_length, extension) == 0;
+}
+
+inline bool is_resource_file_name(const char *name, const char *extension) {
+	return is_visible_directory_entry(name) && has_exact_extension(name, extension);
+}
+
+} // namespace vangers::files
+
+#endif

--- a/src/units/moveland.cpp
+++ b/src/units/moveland.cpp
@@ -8,27 +8,40 @@
 
 #include "../backg.h"
 #include "../common.h"
+#include "../file_utils.h"
 #include "../sqexp.h"
+
+#include <vector>
+
+#if defined(__unix__) || defined(__APPLE__)
+#	include <sys/stat.h>
+#endif
 
 #if !(defined(__unix__) || defined(__APPLE__))
 static WIN32_FIND_DATA FFdata;
 static HANDLE FFh;
+
+static int should_skip_find_entry(void) {
+	const DWORD ignored_attributes =
+		FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_SYSTEM;
+	return (FFdata.dwFileAttributes & ignored_attributes) ||
+		   !vangers::files::is_visible_directory_entry(FFdata.cFileName);
+}
+
 char *win32_findnext(void) {
-	if (FindNextFile(FFh, &FFdata) == TRUE) {
-		if (FFdata.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
-			return win32_findnext();
-		return FFdata.cFileName;
-	} else {
-		FindClose(FFh);
-		return NULL;
+	while (FindNextFile(FFh, &FFdata) == TRUE) {
+		if (!should_skip_find_entry())
+			return FFdata.cFileName;
 	}
+	FindClose(FFh);
+	return NULL;
 }
 
 char *win32_findfirst(const char *mask) {
 	FFh = FindFirstFile(mask, &FFdata);
 	if (FFh == INVALID_HANDLE_VALUE)
 		return NULL;
-	if (FFdata.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+	if (should_skip_find_entry())
 		return win32_findnext();
 	return FFdata.cFileName;
 }
@@ -755,9 +768,18 @@ static int should_load_world_mobile_location(const char *fname) {
 }
 #endif
 
+#if defined(__unix__) || defined(__APPLE__)
+static int is_regular_file(const std::string &directory, const char *name) {
+	struct stat info;
+	const std::string path = directory + name;
+	return stat(path.c_str(), &info) == 0 && S_ISREG(info.st_mode);
+}
+#endif
+
 void MLload(void) {
 	int i, j, t;
 	XBuffer buf;
+	std::vector<std::string> file_names;
 
 #ifdef _ROAD_
 	int k;
@@ -794,82 +816,45 @@ void MLload(void) {
 			MLTnt[i] = 0;
 	};
 #endif
-	MLTableSize = 0;
 #if !(defined(__unix__) || defined(__APPLE__))
 	buf.init();
 	buf < "data.vot/*.vot";
 	char *fn = win32_findfirst(GetTargetName(buf.GetBuf()));
 	while (fn) {
-		MLTableSize++;
+		if (vangers::files::is_resource_file_name(fn, ".vot")
+#	ifdef _ROAD_
+			&& should_load_world_mobile_location(fn)
+#	endif
+		)
+			file_names.emplace_back(fn);
 		fn = win32_findnext();
 	}
 #else
 	std::string tmp = path_to_world + "data.vot/";
 	struct dirent **namelist;
-	int n;
-	n = scandir(tmp.c_str(), &namelist, 0, alphasort);
+	int n = scandir(tmp.c_str(), &namelist, 0, alphasort);
 	if (n < 0)
 		perror("scandir");
 	else {
 		while (n--) {
-			std::string name = namelist[n]->d_name;
-			if (name.find(".vot")!=std::string::npos
+			const char *name = namelist[n]->d_name;
+			if (vangers::files::is_resource_file_name(name, ".vot") &&
+				is_regular_file(tmp, name)
 #	ifdef _ROAD_
-				&& should_load_world_mobile_location(name.c_str())
+				&& should_load_world_mobile_location(name)
 #	endif
 				)
-				MLTableSize++;
+				file_names.emplace_back(name);
 			free(namelist[n]);
 		}
 		free(namelist);
 	}
-
 #endif
 
-#ifdef _ROAD_
-#	if !(defined(__unix__) || defined(__APPLE__))
-	MLTableSize -= NumSkipLocation[CurrentWorld] - RealNumLocation[CurrentWorld];
-#	endif
-#endif
-
+	MLTableSize = static_cast<int>(file_names.size());
 	MLTable = new MobileLocation *[MLTableSize];
-	i = 0;
-#if !(defined(__unix__) || defined(__APPLE__))
-	fn = win32_findfirst(GetTargetName(buf.GetBuf()));
-	while (fn) {
-		t = 1;
-#	ifdef _ROAD_
-		t = should_load_world_mobile_location(fn);
-#	endif
-		if (t) {
-			(MLTable[i] = new MobileLocation)->load(fn);
-			i++;
-		}
-		fn = win32_findnext();
-	};
-#else
-	struct dirent **namelist2;
-	n = scandir(tmp.c_str(), &namelist2, 0, alphasort);
-	if (n < 0)
-		perror("scandir");
-	else {
-		while (n--) {
-			std::string name = namelist2[n]->d_name;
-			if (name.find(".vot") != std::string::npos) {
-				t = 1;
-#	ifdef _ROAD_
-				t = should_load_world_mobile_location(name.c_str());
-#	endif
-				if (t) {
-					(MLTable[i] = new MobileLocation)->load(namelist2[n]->d_name);
-					i++;
-				}
-			}
-			free(namelist2[n]);
-		}
-		free(namelist2);
-	}
-#endif
+	for (i = 0; i < MLTableSize; i++)
+		(MLTable[i] = new MobileLocation)->load(file_names[i].data());
 	VLload();
 	ML_FRAME_DELTA = new uchar[ML_FRAME_SIZE];
 	ML_FRAME_TERRAIN = new uchar[ML_FRAME_SIZE];

--- a/surmap/missed.cpp
+++ b/surmap/missed.cpp
@@ -20,6 +20,7 @@ typedef unsigned char uchar;
 #include "../src/actint/item_api.h"
 #include "../src/common.h"
 #include "../src/dast/poly3d.h"
+#include "../src/file_utils.h"
 #include "../src/network.h"
 #include "../src/sound/hsound.h"
 #include "../src/units/hobj.h"
@@ -145,12 +146,7 @@ char *win32_findfirst(const char *cMask) {
 		path.c_str(),
 		&lastSearch,
 		[](const struct dirent *next) -> int {
-			std::string name = next->d_name;
-			if (extToSearch.length() > name.length()) {
-				return false;
-			}
-			return extToSearch ==
-				   name.substr(name.length() - extToSearch.length(), extToSearch.length());
+			return vangers::files::is_resource_file_name(next->d_name, extToSearch.c_str());
 		},
 		alphasort
 	);


### PR DESCRIPTION
## Problem

On macOS, especially when the Steam library is stored on exFAT or another non-native filesystem, the OS creates AppleDouble metadata files such as `._0000.vot` next to game resources.

The Unix `MLload()` implementation treated any directory entry containing `.vot` as a mobile-location resource. It therefore passed AppleDouble metadata to `MobileLocation::load()`, where `MLverify()` rejected the non-`ML3` header and aborted world loading with:

```text
ML-VOT invalid format
```

This is the confirmed cause of #669.

## Fix

- Add a shared filename predicate for automatically discovered resources.
- Reject empty and hidden names, including AppleDouble and `.DS_Store` entries.
- Require the requested extension to be the exact filename suffix, rejecting files such as `location.vot.bak`.
- On Unix, require discovered world VOT entries to be regular files.
- On Windows, ignore directory, hidden, and system entries returned by `FindFirstFile`.
- Apply the same hidden-file policy to the Unix Surmap resource finder.

`MLload()` now enumerates `data.vot` once, applies the existing per-world selection while collecting filenames, derives `MLTableSize` from that exact list, and then loads the collected entries. This removes the former count/load double scan and guarantees that allocation and loading use the same inputs.

## Safety

The filter is applied only to automatic directory discovery. Explicitly named resources are unchanged, and visible `.vot` files are still parsed normally. Consequently, a genuinely corrupted game resource still reports `ML-VOT invalid format`; the fix does not hide damaged game data.

The existing filename order and per-world mobile-location selection are preserved.

## Verification

- Clean Release configuration and complete 132-target build:
  - game client
  - C++ server
  - Surmap
  - utility targets
- Existing incremental build completed successfully.
- `clang-format --dry-run --Werror` passed for all changed files.
- `git diff --check` passed.
- Focused assertions covered accepted resource names and rejected AppleDouble, hidden, wrong-extension, and backup names.
- The Windows attribute-filter code compiled successfully with MinGW-w64.

Closes #669.
