### PR TITLE
Restore startup intro video playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ http://www.gog.com/game/vangers
 * SDL2_net
 * libvorbis
 * clunk (https://github.com/stalkerg/clunk)
-* ffmpeg
+* ffmpeg 6.0 or newer
 * zlib
 
 You can see the [wiki pages](https://github.com/KranX/Vangers/wiki) to learn how to build this project.

--- a/cmake/FindFFMPEG.cmake
+++ b/cmake/FindFFMPEG.cmake
@@ -11,7 +11,6 @@ FIND_PATH(AVUTIL_INCLUDE_DIR
 		avutil.h
 	PATHS
 		/usr/local/include
-		/usr/pkg/include/ffmpeg3/libavutil
 		/usr/include
 		/usr/include/x86_64-linux-gnu
 		/usr/include/aarch64-linux-gnu
@@ -34,7 +33,6 @@ FIND_PATH(AVCODEC_INCLUDE_DIR
 		avcodec.h
 	PATHS
 		/usr/local/include
-		/usr/pkg/include/ffmpeg3/libavcodec
 		/usr/include
 		/usr/include/x86_64-linux-gnu
 		/usr/include/aarch64-linux-gnu
@@ -57,7 +55,6 @@ FIND_PATH(AVFORMAT_INCLUDE_DIR
 		avformat.h
 	PATHS
 		/usr/local/include
-		/usr/pkg/include/ffmpeg3/libavformat
 		/usr/include
 		/usr/include/x86_64-linux-gnu
 		/usr/include/aarch64-linux-gnu
@@ -80,7 +77,6 @@ FIND_PATH(SWSCALE_INCLUDE_DIR
 		swscale.h
 	PATHS
 		/usr/local/include
-		/usr/pkg/include/ffmpeg3/libswscale
 		/usr/include
 		/usr/include/x86_64-linux-gnu
 		/usr/include/aarch64-linux-gnu
@@ -100,16 +96,12 @@ FIND_PATH(SWSCALE_INCLUDE_DIR
 FIND_LIBRARY(AVUTIL_LIBRARY
 	NAMES
 		avutil
-		avutil-55
-		avutil-56
-		avutil-57
 		avutil-58
 		avutil-59
 		avutil-60
 		avutil-61
 	PATHS
 		/usr/local/lib
-		/usr/pkg/lib/ffmpeg3
 		/usr/lib
 		/usr/lib/x86_64-linux-gnu
 		/usr/lib/aarch64-linux-gnu
@@ -126,16 +118,12 @@ FIND_LIBRARY(AVUTIL_LIBRARY
 FIND_LIBRARY(AVCODEC_LIBRARY
 	NAMES
 		avcodec
-		avcodec-57
-		avcodec-58
-		avcodec-59
 		avcodec-60
 		avcodec-61
 		avcodec-62
 		avcodec-63
 	PATHS
 		/usr/local/lib
-		/usr/pkg/lib/ffmpeg3
 		/usr/lib
 		/usr/lib/x86_64-linux-gnu
 		/usr/lib/aarch64-linux-gnu
@@ -151,16 +139,12 @@ FIND_LIBRARY(AVCODEC_LIBRARY
 FIND_LIBRARY(AVFORMAT_LIBRARY
 	NAMES
 		avformat
-		avformat-57
-		avformat-58
-		avformat-59
 		avformat-60
 		avformat-61
 		avformat-62
 		avformat-63
 	PATHS
 		/usr/local/lib
-		/usr/pkg/lib/ffmpeg3
 		/usr/lib
 		/usr/lib/x86_64-linux-gnu
 		/usr/lib/aarch64-linux-gnu
@@ -177,16 +161,12 @@ FIND_LIBRARY(AVFORMAT_LIBRARY
 FIND_LIBRARY(SWSCALE_LIBRARY
 	NAMES
 		swscale
-		swscale-4
-		swscale-5
-		swscale-6
 		swscale-7
 		swscale-8
 		swscale-9
 		swscale-10
 	PATHS
 		/usr/local/lib
-		/usr/pkg/lib/ffmpeg3
 		/usr/lib
 		/usr/lib/x86_64-linux-gnu
 		/usr/lib/aarch64-linux-gnu

--- a/cmake/FindFFMPEG.cmake
+++ b/cmake/FindFFMPEG.cmake
@@ -1,7 +1,7 @@
 # Locate the FFmpeg libraries
 # This module defines
-# {AVUTIL,AVCODEC,AVFORMAT}_INCLUDE_DIR
-# {AVUTIL,AVCODEC,AVFORMAT}_LIBRARY
+# {AVUTIL,AVCODEC,AVFORMAT,SWSCALE}_INCLUDE_DIR
+# {AVUTIL,AVCODEC,AVFORMAT,SWSCALE}_LIBRARY
 # FFMPEG_INLUDE_DIRS
 # FFMPEG_LIBRARIES
 #
@@ -72,6 +72,28 @@ FIND_PATH(AVFORMAT_INCLUDE_DIR
 		/usr/include/ffmpeg/libavformat
 	PATH_SUFFIXES
 		libavformat
+		ffmpeg
+)
+
+FIND_PATH(SWSCALE_INCLUDE_DIR
+	NAMES
+		swscale.h
+	PATHS
+		/usr/local/include
+		/usr/pkg/include/ffmpeg3/libswscale
+		/usr/include
+		/usr/include/x86_64-linux-gnu
+		/usr/include/aarch64-linux-gnu
+		/opt/local/include
+		/local/include
+		/mingw/include
+		/opt/include
+		/sw/include
+		/usr/include/libswscale
+		/usr/include/ffmpeg
+		/usr/include/ffmpeg/libswscale
+	PATH_SUFFIXES
+		libswscale
 		ffmpeg
 )
 
@@ -152,12 +174,39 @@ FIND_LIBRARY(AVFORMAT_LIBRARY
 		/bin
 )
 
+FIND_LIBRARY(SWSCALE_LIBRARY
+	NAMES
+		swscale
+		swscale-4
+		swscale-5
+		swscale-6
+		swscale-7
+		swscale-8
+		swscale-9
+		swscale-10
+	PATHS
+		/usr/local/lib
+		/usr/pkg/lib/ffmpeg3
+		/usr/lib
+		/usr/lib/x86_64-linux-gnu
+		/usr/lib/aarch64-linux-gnu
+		/usr/lib/ffmpeg
+		/opt/local/lib
+		/sw/lib
+		/local/lib
+		/local/bin
+		/mingw/bin
+		/mingw/lib
+		/bin
+)
+
 get_filename_component(FFMPEG_PARENT_DIR ${AVCODEC_INCLUDE_DIR} DIRECTORY)
 
 SET(FFMPEG_INCLUDE_DIRS
 	#${AVUTIL_INCLUDE_DIR}
 	${AVCODEC_INCLUDE_DIR}
 	${AVFORMAT_INCLUDE_DIR}
+	${SWSCALE_INCLUDE_DIR}
 	${FFMPEG_PARENT_DIR}
 )
 
@@ -184,9 +233,16 @@ IF(AVFORMAT_LIBRARY)
 	)
 ENDIF(AVFORMAT_LIBRARY)
 
-IF(FFMPEG_INCLUDE_DIRS AND FFMPEG_LIBRARIES)
+IF(SWSCALE_LIBRARY)
+	SET(FFMPEG_LIBRARIES
+		${FFMPEG_LIBRARIES}
+		${SWSCALE_LIBRARY}
+	)
+ENDIF(SWSCALE_LIBRARY)
+
+IF(FFMPEG_INCLUDE_DIRS AND FFMPEG_LIBRARIES AND SWSCALE_INCLUDE_DIR AND SWSCALE_LIBRARY)
 	SET(FFMPEG_FOUND TRUE)
-ENDIF(FFMPEG_INCLUDE_DIRS AND FFMPEG_LIBRARIES)
+ENDIF(FFMPEG_INCLUDE_DIRS AND FFMPEG_LIBRARIES AND SWSCALE_INCLUDE_DIR AND SWSCALE_LIBRARY)
 
 IF(FFMPEG_FOUND)
 	IF(NOT FFMPEG_FIND_QUIETLY)

--- a/lib/xsound/_xsound.h
+++ b/lib/xsound/_xsound.h
@@ -1,6 +1,8 @@
 #ifndef __XSOUND_H
 #define __XSOUND_H
 
+#include <cstddef>
+
 #include <clunk/clunk.h>
 
 #define DS_LOOPING 0x00000001
@@ -31,6 +33,15 @@ void SoundRelease(void *lpDSB);
 void SoundStop(int channel);
 void *GetSound(int channel);
 void SoundLoad(char *filename, void **lpDSB);
+void SoundLoadRaw(
+	const char *name,
+	const void *data,
+	std::size_t size,
+	int frequency,
+	Uint16 format,
+	Uint8 channels,
+	void **lpDSB
+);
 void SoundFinit(void);
 void SoundVolume(int channel, int volume);
 void SetVolume(void *lpDSB, int volume);

--- a/lib/xsound/avi.cpp
+++ b/lib/xsound/avi.cpp
@@ -1,7 +1,15 @@
 /* ---------------------------- INCLUDE SECTION ----------------------------- */
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <algorithm>
+#include <cstring>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+extern "C" {
+#include <libavutil/mem.h>
+#include <libswscale/swscale.h>
+}
 
 #include "_xsound.h"
 #include "avi.h"
@@ -21,7 +29,6 @@ void xtUnRegisterSysFinitFnc(int id);
 
 #define AV_CODEC_PAR (LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 33, 100))
 
-// compatability with newer libavcodec
 #if LIBAVCODEC_VERSION_MAJOR < 57
 #	define AV_FRAME_ALLOC avcodec_alloc_frame
 #	define AV_PACKET_UNREF av_free_packet
@@ -44,36 +51,49 @@ void xtUnRegisterSysFinitFnc(int id);
 
 static XList aviXList;
 
-AVIFile::AVIFile(void) {}
+AVIFile::AVIFile(void)
+	: pFormatCtx(NULL), pCodecCtx(NULL), pCodec(NULL), pFrame(NULL), pNextFrame(NULL), packet{},
+	  videoStream(-1), swsContext(NULL), rgbaFrame(NULL), rgbaWidth(0), rgbaHeight(0),
+	  rgbaLineSize(0), avCriticalSection(SDL_CreateMutex()), pause(1), width(0), height(0), x(0),
+	  y(0), redraw(0), released(0), flags(0), frameReady(0), pendingFrameReady(0), inputEof(0),
+	  flushSent(0), decodeFinished(0), converted(0), decodedFrameCount(0),
+	  firstVideoPts(AV_NOPTS_VALUE), currentFrameTime(0), pendingFrameTime(0),
+	  lastDecodedFrameTime(0), frameDuration(1000.0 / 15.0), playbackStart(0), audioSample(NULL),
+	  audioChannel(0), audioPlaying(0) {}
 
-AVIFile::AVIFile(char *aviname, int initFlags, int channel) {
+AVIFile::AVIFile(char *aviname, int initFlags, int channel): AVIFile() {
 	open(aviname, initFlags, channel);
 }
 
 int AVIFile::open(char *aviname, int initFlags, int channel) {
-	int i;
 	filename = aviname;
+	flags = initFlags;
+	audioChannel = channel;
+
+	if (!avCriticalSection) {
+		std::cout << "Couldn't create video mutex" << std::endl;
+		return 0;
+	}
+	if (flags & AVI_INTERPOLATE)
+		return 0;
+
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 9, 100)
 	av_register_all();
 #endif
-	// Open video file
-	pFormatCtx = NULL;
 
 	int ret = avformat_open_input(&pFormatCtx, aviname, NULL, NULL);
-	if (ret != 0) {
-		char error_message[256];
-		av_strerror(ret, error_message, 256);
-		std::cout << "Couldn't open video file:" << aviname << " " << error_message << std::endl;
-		return 0; // Couldn't open file
+	if (ret < 0) {
+		char error_message[AV_ERROR_MAX_STRING_SIZE];
+		av_strerror(ret, error_message, sizeof(error_message));
+		std::cout << "Couldn't open video file: " << aviname << " " << error_message << std::endl;
+		return 0;
 	}
-	// Retrieve stream information
 	if (avformat_find_stream_info(pFormatCtx, NULL) < 0) {
-		std::cout << "Couldn't find stream information file:" << aviname << std::endl;
-		return 0; // Couldn't find stream information
+		std::cout << "Couldn't find stream information file: " << aviname << std::endl;
+		return 0;
 	}
-	// Find the first video stream
-	videoStream = -1;
-	for (i = 0; i < static_cast<int>(pFormatCtx->nb_streams); i++)
+
+	for (unsigned i = 0; i < pFormatCtx->nb_streams; i++) {
 #if AV_CODEC_PAR
 		if (pFormatCtx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
 #else
@@ -82,20 +102,20 @@ int AVIFile::open(char *aviname, int initFlags, int channel) {
 			videoStream = i;
 			break;
 		}
+	}
 	if (videoStream == -1) {
-		std::cout << "Didn't find a video stream file:" << aviname << std::endl;
-		return 0; // Didn't find a video stream
+		std::cout << "Didn't find a video stream file: " << aviname << std::endl;
+		return 0;
 	}
 
-	// Get a pointer to the codec context for the video stream
 #if AV_CODEC_PAR
 	pCodecCtx = avcodec_alloc_context3(NULL);
 	if (!pCodecCtx) {
-		std::cout << "Unabled to allocate codec context";
+		std::cout << "Unable to allocate codec context" << std::endl;
 		return 0;
 	}
 	ret = avcodec_parameters_to_context(pCodecCtx, pFormatCtx->streams[videoStream]->codecpar);
-	if (ret != 0) {
+	if (ret < 0) {
 		std::cout << "Couldn't get the codec context" << std::endl;
 		return 0;
 	}
@@ -103,130 +123,259 @@ int AVIFile::open(char *aviname, int initFlags, int channel) {
 	pCodecCtx = pFormatCtx->streams[videoStream]->codec;
 #endif
 
-	// Find the decoder for the video stream
 	pCodec = avcodec_find_decoder(pCodecCtx->codec_id);
-	if (pCodec == NULL) {
-		std::cout << "Unsupported codec! file:" << aviname << std::endl;
-		return 0; // Codec not found
+	if (!pCodec) {
+		std::cout << "Unsupported codec! file: " << aviname << std::endl;
+		return 0;
 	}
-	// Open codec
-#if (LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(53, 8, 0))
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(53, 8, 0)
 	if (avcodec_open2(pCodecCtx, pCodec, NULL) < 0) {
 #else
 	if (avcodec_open(pCodecCtx, pCodec) < 0) {
 #endif
-		std::cout << "Could not open codec file:" << aviname << std::endl;
-		return 0; // Could not open codec
+		std::cout << "Could not open codec file: " << aviname << std::endl;
+		return 0;
 	}
 
-	// Allocate video frame
 	pFrame = AV_FRAME_ALLOC();
+	pNextFrame = AV_FRAME_ALLOC();
+	if (!pFrame || !pNextFrame) {
+		std::cout << "Unable to allocate video frames" << std::endl;
+		return 0;
+	}
 
 	width = pCodecCtx->width;
 	height = pCodecCtx->height;
-	flags = initFlags;
-	if (flags & AVI_INTERPOLATE)
-		return 0; // XXX: add support for palettes
-
-	released = redraw = x = y = 0;
-
-	if (flags & AVI_DRAW) {
-		draw();
+	if (width <= 0 || height <= 0 || width > std::numeric_limits<int>::max() / 4) {
+		std::cout << "Invalid video dimensions file: " << aviname << std::endl;
+		return 0;
 	}
-	avCriticalSection = SDL_CreateMutex();
-	pause = 1;
+	rgbaLineSize = width * 4;
+	if ((size_t)height > std::numeric_limits<size_t>::max() / rgbaLineSize) {
+		std::cout << "Video frame is too large file: " << aviname << std::endl;
+		return 0;
+	}
+	rgbaFrame = (uint8_t *)av_malloc((size_t)rgbaLineSize * height);
+	if (!rgbaFrame) {
+		std::cout << "Unable to allocate converted video frame" << std::endl;
+		return 0;
+	}
+	rgbaWidth = width;
+	rgbaHeight = height;
+
+	AVRational frame_rate = av_guess_frame_rate(pFormatCtx, pFormatCtx->streams[videoStream], NULL);
+	if (frame_rate.num > 0 && frame_rate.den > 0)
+		frameDuration = 1000.0 * frame_rate.den / frame_rate.num;
+
+	if (!(flags & AVI_NOTIMER))
+		loadAudio(aviname);
+
+	if (flags & AVI_DRAW)
+		draw();
+	return 1;
+}
+
+void AVIFile::loadAudio(const char *aviname) {
+	AVFormatContext *audioFormat = NULL;
+	if (avformat_open_input(&audioFormat, aviname, NULL, NULL) < 0)
+		return;
+	if (avformat_find_stream_info(audioFormat, NULL) < 0) {
+		avformat_close_input(&audioFormat);
+		return;
+	}
+
+	int audio_stream = -1;
+	int sample_rate = 0;
+	int channels = 0;
+	AVCodecID codec_id = AV_CODEC_ID_NONE;
+	for (unsigned i = 0; i < audioFormat->nb_streams; i++) {
+#if AV_CODEC_PAR
+		AVCodecParameters *parameters = audioFormat->streams[i]->codecpar;
+		if (parameters->codec_type != AVMEDIA_TYPE_AUDIO)
+			continue;
+		codec_id = parameters->codec_id;
+		sample_rate = parameters->sample_rate;
+#	if LIBAVCODEC_VERSION_MAJOR >= 59
+		channels = parameters->ch_layout.nb_channels;
+#	else
+		channels = parameters->channels;
+#	endif
+#else
+		AVCodecContext *context = audioFormat->streams[i]->codec;
+		if (context->codec_type != AVMEDIA_TYPE_AUDIO)
+			continue;
+		codec_id = context->codec_id;
+		sample_rate = context->sample_rate;
+		channels = context->channels;
+#endif
+		audio_stream = i;
+		break;
+	}
+
+	if (audio_stream == -1 || codec_id != AV_CODEC_ID_PCM_S16LE || sample_rate <= 0 ||
+		(channels != 1 && channels != 2)) {
+		avformat_close_input(&audioFormat);
+		return;
+	}
+
+	std::vector<uint8_t> samples;
+	AVPacket audio_packet{};
+	while (av_read_frame(audioFormat, &audio_packet) >= 0) {
+		if (audio_packet.stream_index == audio_stream && audio_packet.size > 0) {
+			samples.insert(samples.end(), audio_packet.data, audio_packet.data + audio_packet.size);
+		}
+		AV_PACKET_UNREF(&audio_packet);
+	}
+	AV_PACKET_UNREF(&audio_packet);
+	avformat_close_input(&audioFormat);
+
+	const size_t sample_size = sizeof(int16_t) * channels;
+	samples.resize(samples.size() - samples.size() % sample_size);
+	if (samples.empty())
+		return;
+
+	std::string sample_name = "avi:" + filename;
+	SoundLoadRaw(
+		sample_name.c_str(),
+		samples.data(),
+		samples.size(),
+		sample_rate,
+		AUDIO_S16LSB,
+		channels,
+		&audioSample
+	);
+}
+
+int AVIFile::decodeNextFrame(AVFrame *frame) {
+	av_frame_unref(frame);
+	while (true) {
+		int ret = avcodec_receive_frame(pCodecCtx, frame);
+		if (ret == 0)
+			return 1;
+		if (ret == AVERROR_EOF)
+			return 0;
+		if (ret != AVERROR(EAGAIN)) {
+			std::cout << "Can't receive video frame: " << filename << std::endl;
+			return 0;
+		}
+
+		if (inputEof) {
+			if (flushSent)
+				return 0;
+			ret = avcodec_send_packet(pCodecCtx, NULL);
+			flushSent = 1;
+			if (ret < 0 && ret != AVERROR_EOF) {
+				std::cout << "Can't flush video decoder: " << filename << std::endl;
+				return 0;
+			}
+			continue;
+		}
+
+		while (true) {
+			ret = av_read_frame(pFormatCtx, &packet);
+			if (ret < 0) {
+				inputEof = 1;
+				break;
+			}
+			if (packet.stream_index != videoStream) {
+				AV_PACKET_UNREF(&packet);
+				continue;
+			}
+
+			ret = avcodec_send_packet(pCodecCtx, &packet);
+			AV_PACKET_UNREF(&packet);
+			if (ret < 0) {
+				std::cout << "Can't send video packet: " << filename << std::endl;
+				return 0;
+			}
+			break;
+		}
+	}
+}
+
+double AVIFile::frameTime(const AVFrame *frame) {
+	double result = decodedFrameCount * frameDuration;
+	if (frame->best_effort_timestamp != AV_NOPTS_VALUE) {
+		if (firstVideoPts == AV_NOPTS_VALUE)
+			firstVideoPts = frame->best_effort_timestamp;
+		result = av_q2d(pFormatCtx->streams[videoStream]->time_base) *
+				 (frame->best_effort_timestamp - firstVideoPts) * 1000.0;
+	}
+	if (decodedFrameCount && result <= lastDecodedFrameTime)
+		result = lastDecodedFrameTime + frameDuration;
+	lastDecodedFrameTime = result;
+	decodedFrameCount++;
+	return result;
+}
+
+int AVIFile::rewindVideo(void) {
+	if (av_seek_frame(pFormatCtx, videoStream, 0, AVSEEK_FLAG_BACKWARD) < 0)
+		return 0;
+	avcodec_flush_buffers(pCodecCtx);
+	av_frame_unref(pFrame);
+	av_frame_unref(pNextFrame);
+	frameReady = 0;
+	pendingFrameReady = 0;
+	inputEof = 0;
+	flushSent = 0;
+	decodeFinished = 0;
+	converted = 0;
+	decodedFrameCount = 0;
+	firstVideoPts = AV_NOPTS_VALUE;
+	currentFrameTime = 0;
+	pendingFrameTime = 0;
+	lastDecodedFrameTime = 0;
+	playbackStart = SDL_GetTicks();
 	return 1;
 }
 
 void AVIFile::draw(void) {
-	if (pause)
+	if (pause || released)
 		return;
-	int i, frameFinished = 0;
-	if (!released) {
+
+	XCriticalSection critical(avCriticalSection);
+	if (flags & AVI_NOTIMER) {
+		if (!decodeNextFrame(pFrame)) {
+			if (!(flags & AVI_LOOPING) || !rewindVideo() || !decodeNextFrame(pFrame)) {
+				decodeFinished = 1;
+				return;
+			}
+		}
+		frameReady = 1;
+		converted = 0;
 		redraw = 1;
-		int frame = -1;
-		while ((frame = av_read_frame(pFormatCtx, &packet)) >= 0) {
-			// Is this a packet from the video stream?
-			if (packet.stream_index == videoStream) {
-				// Decode video frame
-#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 106, 102)
-				while (true) {
-					int ret = avcodec_send_packet(pCodecCtx, &packet);
-					if (ret != 0 && ret != AVERROR(EAGAIN)) {
-						std::cout << "Can't send packet" << std::endl;
-						return;
-					}
-					ret = avcodec_receive_frame(pCodecCtx, pFrame);
-					if (ret == 0 || ret == AVERROR_EOF) {
-						frameFinished = 1;
-					} else if (ret == AVERROR(EAGAIN)) {
-						std::cout << "Can't receive the frame, try it again" << std::endl;
-						continue;
-					} else {
-						std::cout << "Can't receive the frame" << std::endl;
-						return;
-					}
-					break;
-				}
-#elif LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(52, 23, 0)
-				avcodec_decode_video2(pCodecCtx, pFrame, &frameFinished, &packet);
-#else
-				avcodec_decode_video(pCodecCtx, pFrame, &frameFinished, packet.data, packet.size);
-#endif
-				// Did we get a video frame?
-				if (frameFinished) {
-					AV_PACKET_UNREF(&packet);
-					break;
-				}
-			}
-			AV_PACKET_UNREF(&packet);
+		return;
+	}
+
+	if (!frameReady) {
+		if (!decodeNextFrame(pFrame)) {
+			decodeFinished = 1;
+			return;
 		}
-		if (frame < 0 && (flags & AVI_LOOPING)) {
-			// Close the codec
-			AV_CODEC_CONTEXT_RELEASE(pCodecCtx);
-			// Close the video file
-			// av_close_input_file(pFormatCtx);
-			avformat_close_input(&pFormatCtx);
-			// Open video file
-			int ret = avformat_open_input(&pFormatCtx, filename.c_str(), NULL, NULL);
-			if (ret != 0) {
-				std::cout << "Couldn't open video file" << std::endl;
-				return; // Couldn't open file
+		currentFrameTime = frameTime(pFrame);
+		frameReady = 1;
+		converted = 0;
+		redraw = 1;
+	}
+
+	const double elapsed = (Uint32)(SDL_GetTicks() - playbackStart);
+	while (true) {
+		if (!pendingFrameReady && !decodeFinished) {
+			if (decodeNextFrame(pNextFrame)) {
+				pendingFrameTime = frameTime(pNextFrame);
+				pendingFrameReady = 1;
+			} else {
+				decodeFinished = 1;
 			}
-			// Get a pointer to the codec context for the video stream
-#if AV_CODEC_PAR
-			pCodecCtx = avcodec_alloc_context3(NULL);
-			if (!pCodecCtx) {
-				std::cout << "Unabled to allocate codec context";
-				return;
-			}
-			ret = avcodec_parameters_to_context(
-				pCodecCtx, pFormatCtx->streams[videoStream]->codecpar
-			);
-			if (ret != 0) {
-				std::cout << "Couldn't get the codec context" << std::endl;
-				return;
-			}
-#else
-			pCodecCtx = pFormatCtx->streams[videoStream]->codec;
-#endif
-			// Find the decoder for the video stream
-			pCodec = avcodec_find_decoder(pCodecCtx->codec_id);
-			if (pCodec == NULL) {
-				std::cout << "Unsupported codec!" << std::endl;
-				return; // Codec not found
-			}
-			// Open codec
-#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(53, 8, 0)
-			if (avcodec_open2(pCodecCtx, pCodec, NULL) < 0) {
-#else
-			if (avcodec_open(pCodecCtx, pCodec) < 0) {
-#endif
-				std::cout << "Could not open codec" << std::endl;
-				return; // Could not open codec
-			}
-			draw();
 		}
+		if (!pendingFrameReady || pendingFrameTime > elapsed)
+			break;
+
+		std::swap(pFrame, pNextFrame);
+		currentFrameTime = pendingFrameTime;
+		pendingFrameReady = 0;
+		converted = 0;
+		redraw = 1;
 	}
 }
 
@@ -235,46 +384,95 @@ AVIFile::~AVIFile() {
 }
 
 void AVIFile::close(void) {
+	if (released)
+		return;
 	released = 1;
-	SDL_mutexP(avCriticalSection);
-	// Free the YUV frame
-	AV_FRAME_FREE(pFrame);
-	// Close the codec
-	AV_CODEC_CONTEXT_RELEASE(pCodecCtx);
-	// Close the video file
-	// av_close_input_file(pFormatCtx);
-	// avformat_free_context(pFormatCtx);
-	avformat_close_input(&pFormatCtx);
 
-	SDL_mutexV(avCriticalSection);
-	SDL_DestroyMutex(avCriticalSection);
+	if (audioPlaying) {
+		SoundStop(audioChannel);
+		audioPlaying = 0;
+	}
+	if (audioSample) {
+		SoundRelease(audioSample);
+		audioSample = NULL;
+	}
+
+	if (avCriticalSection)
+		SDL_LockMutex(avCriticalSection);
+	AV_PACKET_UNREF(&packet);
+	if (swsContext) {
+		sws_freeContext(swsContext);
+		swsContext = NULL;
+	}
+	av_freep(&rgbaFrame);
+	AV_FRAME_FREE(pNextFrame);
+	AV_FRAME_FREE(pFrame);
+	if (pCodecCtx) {
+		AV_CODEC_CONTEXT_RELEASE(pCodecCtx);
+		pCodecCtx = NULL;
+	}
+	if (pFormatCtx)
+		avformat_close_input(&pFormatCtx);
+
+	if (avCriticalSection) {
+		SDL_UnlockMutex(avCriticalSection);
+		SDL_DestroyMutex(avCriticalSection);
+		avCriticalSection = NULL;
+	}
+}
+
+int AVIFile::isFinished(void) const {
+	if (!decodeFinished)
+		return 0;
+	if (!frameReady || (flags & AVI_NOTIMER))
+		return 1;
+	const double elapsed = (Uint32)(SDL_GetTicks() - playbackStart);
+	return elapsed >= currentFrameTime + frameDuration;
 }
 
 int AVIopen(char *filename, int flags, int channel, void **avi) {
+	*avi = NULL;
 	AVIFile *newavi = new AVIFile;
-
-	if (!newavi->open(filename, flags, channel))
+	if (!newavi->open(filename, flags, channel)) {
+		delete newavi;
 		return 0;
+	}
 
 	*avi = newavi;
 	aviXList.AddElement((XListElement *)newavi);
-
 	xtRegisterSysFinitFnc(FinitAVI, XAVI_SYSOBJ_ID);
 	return 1;
 }
 
 void AVIplay(void *avi, int xx, int yy) {
-	((AVIFile *)avi)->pause = 0;
-	((AVIFile *)avi)->x = xx;
-	((AVIFile *)avi)->y = yy;
+	AVIFile *file = (AVIFile *)avi;
+	if (!file || file->released)
+		return;
+	file->pause = 0;
+	file->x = xx;
+	file->y = yy;
+	file->playbackStart = SDL_GetTicks();
+	if (file->audioSample && !file->audioPlaying) {
+		SoundPlay(file->audioSample, file->audioChannel, 0, 0, 0);
+		file->audioPlaying = 1;
+	}
 }
 
 void AVIstop(void *avi) {
-	((AVIFile *)avi)->pause = 1;
+	AVIFile *file = (AVIFile *)avi;
+	if (!file)
+		return;
+	file->pause = 1;
+	if (file->audioPlaying) {
+		SoundStop(file->audioChannel);
+		file->audioPlaying = 0;
+	}
 }
 
 void AVIclose(void *avi) {
 	AVIFile *p = (AVIFile *)avi;
+	if (!p)
+		return;
 	aviXList.RemoveElement((XListElement *)p);
 	delete p;
 }
@@ -295,8 +493,13 @@ void AVIredraw(void *avi, int state) {
 	((AVIFile *)avi)->redraw = state;
 }
 
+int AVIisFinished(void *avi) {
+	return !avi || ((AVIFile *)avi)->isFinished();
+}
+
 void AVIPrepareFrame(void *avi) {
-	((AVIFile *)avi)->draw();
+	if (avi)
+		((AVIFile *)avi)->draw();
 }
 
 void AVIDrawFrame(
@@ -305,64 +508,104 @@ void AVIDrawFrame(
 	int offsetY,
 	int lineWidth,
 	uint32_t *rgba,
-	float bright
+	float bright,
+	int outputWidth,
+	int outputHeight
 ) {
-	XCriticalSection critical(((AVIFile *)avi)->avCriticalSection);
-	int width = AVIwidth(avi);
-	int height = AVIheight(avi);
-	bright = std::min(1.0f, bright);
+	AVIFile *file = (AVIFile *)avi;
+	if (!file || !rgba)
+		return;
+	XCriticalSection critical(file->avCriticalSection);
+	if (!file->frameReady)
+		return;
 
-	AVFrame *frame = ((AVIFile *)avi)->pFrame;
-	if (frame->format == AV_PIX_FMT_PAL8) {
-		for (int y = 0; y < height; ++y) {
-			for (int x = 0; x < width; ++x) {
-				int index = frame->data[0][y * frame->linesize[0] + x];
-				uint32_t *pixel = rgba + (y + offsetY) * lineWidth + x + offsetX;
-				*pixel = ((uint32_t *)frame->data[1])[index];
-				((uint8_t *)pixel)[3] = 255;
+	if (outputWidth <= 0)
+		outputWidth = file->width;
+	if (outputHeight <= 0)
+		outputHeight = file->height;
+	if (outputWidth > std::numeric_limits<int>::max() / 4 ||
+		(size_t)outputHeight > std::numeric_limits<size_t>::max() / (outputWidth * 4))
+		return;
 
-				if (bright < 1) {
-					((uint8_t *)pixel)[0] *= bright;
-					((uint8_t *)pixel)[1] *= bright;
-					((uint8_t *)pixel)[2] *= bright;
-				}
-			}
+	if (file->rgbaWidth != outputWidth || file->rgbaHeight != outputHeight) {
+		uint8_t *resized =
+			(uint8_t *)av_realloc(file->rgbaFrame, (size_t)outputWidth * outputHeight * 4);
+		if (!resized)
+			return;
+		file->rgbaFrame = resized;
+		file->rgbaWidth = outputWidth;
+		file->rgbaHeight = outputHeight;
+		file->rgbaLineSize = outputWidth * 4;
+		file->converted = 0;
+	}
+
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+	const AVPixelFormat output_format = AV_PIX_FMT_BGRA;
+#else
+	const AVPixelFormat output_format = AV_PIX_FMT_ARGB;
+#endif
+	if (!file->converted) {
+		file->swsContext = sws_getCachedContext(
+			file->swsContext,
+			file->width,
+			file->height,
+			(AVPixelFormat)file->pFrame->format,
+			file->rgbaWidth,
+			file->rgbaHeight,
+			output_format,
+			SWS_BILINEAR,
+			NULL,
+			NULL,
+			NULL
+		);
+		if (!file->swsContext)
+			return;
+
+		uint8_t *destination[] = {file->rgbaFrame, NULL, NULL, NULL};
+		int destination_lines[] = {file->rgbaLineSize, 0, 0, 0};
+		sws_scale(
+			file->swsContext,
+			file->pFrame->data,
+			file->pFrame->linesize,
+			0,
+			file->height,
+			destination,
+			destination_lines
+		);
+		file->converted = 1;
+	}
+
+	bright = std::max(0.0f, std::min(1.0f, bright));
+	const int source_x = std::max(0, -offsetX);
+	const int source_y = std::max(0, -offsetY);
+	const int end_x = std::min(file->rgbaWidth, lineWidth - offsetX);
+	const int end_y = std::min(file->rgbaHeight, XGR_MAXY - offsetY);
+	if (source_x >= end_x || source_y >= end_y)
+		return;
+
+	for (int y = source_y; y < end_y; y++) {
+		const uint8_t *source = file->rgbaFrame + y * file->rgbaLineSize + source_x * 4;
+		uint8_t *destination = (uint8_t *)(rgba + (y + offsetY) * lineWidth + source_x + offsetX);
+		if (bright == 1.0f) {
+			std::memcpy(destination, source, (end_x - source_x) * 4);
+			continue;
 		}
-	} else if (frame->format == AV_PIX_FMT_YUV444P) {
-		for (int y = 0; y < height; ++y) {
-			for (int x = 0; x < width; ++x) {
-				uint8_t *pixel = (uint8_t *)(rgba + (y + offsetY) * lineWidth + x + offsetX);
-
-				double Y = frame->data[0][y * frame->linesize[0] + x];
-				double U = frame->data[1][y * frame->linesize[0] + x];
-				double V = frame->data[2][y * frame->linesize[0] + x];
-
-				double R = Y + +(U - 128) * 1.40200;
-				double G = Y + (V - 128) * -0.34414 + (U - 128) * -0.71414;
-				double B = Y + (V - 128) * 1.77200;
-
-				pixel[0] = std::max(std::min(R, 255.0), 0.0) * bright;
-				pixel[1] = std::max(std::min(G, 255.0), 0.0) * bright;
-				pixel[2] = std::max(std::min(B, 255.0), 0.0) * bright;
-				pixel[3] = 255;
-			}
-		}
-	} else {
-		static bool warn = true;
-		if (warn) {
-			printf("WARN! Video pixel format '%d' is not supported\n", frame->format);
-			printf("WARN! Video pixel format should be one of pal8, yuv444p\n");
-			warn = false;
+		for (int x = source_x; x < end_x; x++) {
+			destination[0] = source[0] * bright;
+			destination[1] = source[1] * bright;
+			destination[2] = source[2] * bright;
+			destination[3] = source[3];
+			source += 4;
+			destination += 4;
 		}
 	}
 }
 
 void FinitAVI(void) {
-	AVIFile *p, *p1;
-	p = (AVIFile *)aviXList.fPtr;
+	AVIFile *p = (AVIFile *)aviXList.fPtr;
 	while (p) {
-		p1 = (AVIFile *)p->next;
+		AVIFile *next = (AVIFile *)p->next;
 		AVIclose(p);
-		p = p1;
+		p = next;
 	}
 }

--- a/lib/xsound/avi.cpp
+++ b/lib/xsound/avi.cpp
@@ -27,26 +27,11 @@ void xtUnRegisterSysFinitFnc(int id);
 
 /* --------------------------- DEFINITION SECTION --------------------------- */
 
-#define AV_CODEC_PAR (LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 33, 100))
-
-#if LIBAVCODEC_VERSION_MAJOR < 57
-#	define AV_FRAME_ALLOC avcodec_alloc_frame
-#	define AV_PACKET_UNREF av_free_packet
-#else
-#	define AV_FRAME_ALLOC av_frame_alloc
-#	define AV_PACKET_UNREF av_packet_unref
-#endif
-
-#if LIBAVCODEC_VERSION_MAJOR < 55
-#	define AV_FRAME_FREE(frame) av_free(frame)
-#else
-#	define AV_FRAME_FREE(frame) av_frame_free(&(frame))
-#endif
-
-#if AV_CODEC_PAR
-#	define AV_CODEC_CONTEXT_RELEASE(ctx) avcodec_free_context(&(ctx))
-#else
-#	define AV_CODEC_CONTEXT_RELEASE(ctx) avcodec_close(ctx)
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(60, 3, 100) ||  \
+	LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(60, 3, 100) || \
+	LIBAVUTIL_VERSION_INT < AV_VERSION_INT(58, 2, 100) ||   \
+	LIBSWSCALE_VERSION_INT < AV_VERSION_INT(7, 1, 100)
+#	error "FFmpeg 6.0 or newer is required"
 #endif
 
 static XList aviXList;
@@ -77,10 +62,6 @@ int AVIFile::open(char *aviname, int initFlags, int channel) {
 	if (flags & AVI_INTERPOLATE)
 		return 0;
 
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 9, 100)
-	av_register_all();
-#endif
-
 	int ret = avformat_open_input(&pFormatCtx, aviname, NULL, NULL);
 	if (ret < 0) {
 		char error_message[AV_ERROR_MAX_STRING_SIZE];
@@ -94,11 +75,7 @@ int AVIFile::open(char *aviname, int initFlags, int channel) {
 	}
 
 	for (unsigned i = 0; i < pFormatCtx->nb_streams; i++) {
-#if AV_CODEC_PAR
 		if (pFormatCtx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
-#else
-		if (pFormatCtx->streams[i]->codec->codec_type == AVMEDIA_TYPE_VIDEO) {
-#endif
 			videoStream = i;
 			break;
 		}
@@ -107,8 +84,6 @@ int AVIFile::open(char *aviname, int initFlags, int channel) {
 		std::cout << "Didn't find a video stream file: " << aviname << std::endl;
 		return 0;
 	}
-
-#if AV_CODEC_PAR
 	pCodecCtx = avcodec_alloc_context3(NULL);
 	if (!pCodecCtx) {
 		std::cout << "Unable to allocate codec context" << std::endl;
@@ -119,26 +94,19 @@ int AVIFile::open(char *aviname, int initFlags, int channel) {
 		std::cout << "Couldn't get the codec context" << std::endl;
 		return 0;
 	}
-#else
-	pCodecCtx = pFormatCtx->streams[videoStream]->codec;
-#endif
 
 	pCodec = avcodec_find_decoder(pCodecCtx->codec_id);
 	if (!pCodec) {
 		std::cout << "Unsupported codec! file: " << aviname << std::endl;
 		return 0;
 	}
-#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(53, 8, 0)
 	if (avcodec_open2(pCodecCtx, pCodec, NULL) < 0) {
-#else
-	if (avcodec_open(pCodecCtx, pCodec) < 0) {
-#endif
 		std::cout << "Could not open codec file: " << aviname << std::endl;
 		return 0;
 	}
 
-	pFrame = AV_FRAME_ALLOC();
-	pNextFrame = AV_FRAME_ALLOC();
+	pFrame = av_frame_alloc();
+	pNextFrame = av_frame_alloc();
 	if (!pFrame || !pNextFrame) {
 		std::cout << "Unable to allocate video frames" << std::endl;
 		return 0;
@@ -189,25 +157,12 @@ void AVIFile::loadAudio(const char *aviname) {
 	int channels = 0;
 	AVCodecID codec_id = AV_CODEC_ID_NONE;
 	for (unsigned i = 0; i < audioFormat->nb_streams; i++) {
-#if AV_CODEC_PAR
 		AVCodecParameters *parameters = audioFormat->streams[i]->codecpar;
 		if (parameters->codec_type != AVMEDIA_TYPE_AUDIO)
 			continue;
 		codec_id = parameters->codec_id;
 		sample_rate = parameters->sample_rate;
-#	if LIBAVCODEC_VERSION_MAJOR >= 59
 		channels = parameters->ch_layout.nb_channels;
-#	else
-		channels = parameters->channels;
-#	endif
-#else
-		AVCodecContext *context = audioFormat->streams[i]->codec;
-		if (context->codec_type != AVMEDIA_TYPE_AUDIO)
-			continue;
-		codec_id = context->codec_id;
-		sample_rate = context->sample_rate;
-		channels = context->channels;
-#endif
 		audio_stream = i;
 		break;
 	}
@@ -224,9 +179,9 @@ void AVIFile::loadAudio(const char *aviname) {
 		if (audio_packet.stream_index == audio_stream && audio_packet.size > 0) {
 			samples.insert(samples.end(), audio_packet.data, audio_packet.data + audio_packet.size);
 		}
-		AV_PACKET_UNREF(&audio_packet);
+		av_packet_unref(&audio_packet);
 	}
-	AV_PACKET_UNREF(&audio_packet);
+	av_packet_unref(&audio_packet);
 	avformat_close_input(&audioFormat);
 
 	const size_t sample_size = sizeof(int16_t) * channels;
@@ -278,12 +233,12 @@ int AVIFile::decodeNextFrame(AVFrame *frame) {
 				break;
 			}
 			if (packet.stream_index != videoStream) {
-				AV_PACKET_UNREF(&packet);
+				av_packet_unref(&packet);
 				continue;
 			}
 
 			ret = avcodec_send_packet(pCodecCtx, &packet);
-			AV_PACKET_UNREF(&packet);
+			av_packet_unref(&packet);
 			if (ret < 0) {
 				std::cout << "Can't send video packet: " << filename << std::endl;
 				return 0;
@@ -399,17 +354,16 @@ void AVIFile::close(void) {
 
 	if (avCriticalSection)
 		SDL_LockMutex(avCriticalSection);
-	AV_PACKET_UNREF(&packet);
+	av_packet_unref(&packet);
 	if (swsContext) {
 		sws_freeContext(swsContext);
 		swsContext = NULL;
 	}
 	av_freep(&rgbaFrame);
-	AV_FRAME_FREE(pNextFrame);
-	AV_FRAME_FREE(pFrame);
+	av_frame_free(&pNextFrame);
+	av_frame_free(&pFrame);
 	if (pCodecCtx) {
-		AV_CODEC_CONTEXT_RELEASE(pCodecCtx);
-		pCodecCtx = NULL;
+		avcodec_free_context(&pCodecCtx);
 	}
 	if (pFormatCtx)
 		avformat_close_input(&pFormatCtx);

--- a/lib/xsound/avi.h
+++ b/lib/xsound/avi.h
@@ -20,6 +20,8 @@ extern "C" {
 }
 #endif
 
+struct SwsContext;
+
 #define AVI_END_VIDEO 0x00010000
 #define AVI_END_SOUND 0x00020000
 
@@ -28,8 +30,14 @@ struct AVIFile: XListElement {
 	AVCodecContext *pCodecCtx;
 	const AVCodec *pCodec;
 	AVFrame *pFrame;
+	AVFrame *pNextFrame;
 	AVPacket packet;
 	int videoStream;
+	SwsContext *swsContext;
+	uint8_t *rgbaFrame;
+	int rgbaWidth;
+	int rgbaHeight;
+	int rgbaLineSize;
 
 	SDL_mutex *avCriticalSection;
 	int pause;
@@ -41,6 +49,23 @@ struct AVIFile: XListElement {
 	int redraw;
 	int released;
 	int flags;
+	int frameReady;
+	int pendingFrameReady;
+	int inputEof;
+	int flushSent;
+	int decodeFinished;
+	int converted;
+	int decodedFrameCount;
+	int64_t firstVideoPts;
+	double currentFrameTime;
+	double pendingFrameTime;
+	double lastDecodedFrameTime;
+	double frameDuration;
+	Uint32 playbackStart;
+
+	void *audioSample;
+	int audioChannel;
+	int audioPlaying;
 	std::string filename;
 
 	~AVIFile();
@@ -49,6 +74,12 @@ struct AVIFile: XListElement {
 	int open(char *aviname, int flags, int channel);
 	void draw(void);
 	void close(void);
+	int isFinished(void) const;
+
+	int decodeNextFrame(AVFrame *frame);
+	double frameTime(const AVFrame *frame);
+	int rewindVideo(void);
+	void loadAudio(const char *aviname);
 };
 
 int AVIopen(char *filename, int flags, int channel, void **avi);
@@ -59,6 +90,7 @@ int AVIwidth(void *avi);
 int AVIheight(void *avi);
 int AVIredraw(void *avi);
 void AVIredraw(void *avi, int state);
+int AVIisFinished(void *avi);
 
 void AVIPrepareFrame(void *avi);
 void AVIDrawFrame(
@@ -67,7 +99,9 @@ void AVIDrawFrame(
 	int offsetY,
 	int lineWidth,
 	uint32_t *rgba,
-	float bright = 1.0
+	float bright = 1.0,
+	int outputWidth = 0,
+	int outputHeight = 0
 );
 
 #endif //__AVI_H__

--- a/lib/xsound/xsound.cpp
+++ b/lib/xsound/xsound.cpp
@@ -278,6 +278,36 @@ void SoundLoad(char *filename, void **lpDSB) {
 	(*lpDSB) = (void *)chunk;
 }
 
+void SoundLoadRaw(
+	const char *name,
+	const void *data,
+	std::size_t size,
+	int frequency,
+	Uint16 format,
+	Uint8 channels_count,
+	void **lpDSB
+) {
+	clunk::Sample *sample = NULL;
+	if (XSoundInitFlag && data && size) {
+		try {
+			clunk::Buffer buffer;
+			buffer.set_data(data, size);
+			sample = context.create_sample();
+			sample->name = name;
+			sample->init(buffer, frequency, format, channels_count);
+		} catch (const std::exception &e) {
+			std::string message = "Error loading raw sound: ";
+			message += name;
+			message += " ";
+			message += e.what();
+			ErrH.Log(message.c_str());
+			delete sample;
+			sample = NULL;
+		}
+	}
+	*lpDSB = sample;
+}
+
 void SetVolume(void *lpDSB, int volume) {
 	/* SDL_Mixer Version
 	volume+=10000;

--- a/lib/xtool/xtcore.cpp
+++ b/lib/xtool/xtcore.cpp
@@ -93,6 +93,8 @@ XStream xtRTO_Log;
 int xtSysQuantDisabled = 0;
 extern bool XGR_FULL_SCREEN;
 
+int SkipIntro = 0;
+
 bool autoconnect = false;
 char *autoconnectHost;
 unsigned short autoconnectPort = 2197;
@@ -127,6 +129,8 @@ int main(int argc, char *argv[])
 		std::string cmd_key = argv[i];
 		if (cmd_key == "-fullscreen") {
 			XGR_FULL_SCREEN = true;
+		} else if (cmd_key == "-skipintro") {
+			SkipIntro = 1;
 		} else if (cmd_key == "-russian") {
 			setLang(RUSSIAN);
 		} else if (cmd_key == "-server") {

--- a/src/road.cpp
+++ b/src/road.cpp
@@ -18,6 +18,7 @@
 #endif
 
 #include "_xsound.h"
+#include "avi.h"
 
 #define DEFINE_GAME_RTO_TIMERS
 #include "runtime.h"
@@ -252,7 +253,7 @@ int MuteLog = 0;
 int Verbose;
 int DepthShow;
 
-int SkipIntro = 0;
+extern int SkipIntro;
 
 int PalIterLock = 0;
 
@@ -367,6 +368,42 @@ void showModal(char *fname, float reelW, float reelH, float screenW, float scree
 		winVideo.Close(); */
 }
 
+static int LoadStartupFullscreenOption(void) {
+	XStream options(0);
+	if (!options.open("options.dat", XS_IN))
+		return -1;
+
+	const long saved_values_size = 4 * (long)sizeof(int);
+	if (options.size() < (long)sizeof(int) + saved_values_size) {
+		options.close();
+		return -1;
+	}
+
+	int option_count;
+	options > option_count;
+	if (option_count != iMAX_OPTION_ID) {
+		options.close();
+		return -1;
+	}
+
+	int fullscreen;
+	int auto_acceleration;
+	int fps_60;
+	int repeated_auto_acceleration;
+	// These are the final three saved options followed by iSaveData's repeated
+	// auto-acceleration value. The complete options file is loaded normally by the menu later.
+	options.seek(-saved_values_size, XS_END);
+	options > fullscreen > auto_acceleration > fps_60 > repeated_auto_acceleration;
+	options.close();
+
+	if ((fullscreen != 0 && fullscreen != 1) ||
+		(auto_acceleration != 0 && auto_acceleration != 1) || (fps_60 != 0 && fps_60 != 1) ||
+		auto_acceleration != repeated_auto_acceleration)
+		return -1;
+
+	return fullscreen;
+}
+
 int xtInitApplication(void) {
 	XGraphWndID = "VANGERS";
 	char *tmp;
@@ -458,6 +495,11 @@ int xtInitApplication(void) {
 
 	emode = ExclusiveLog ? XGR_EXCLUSIVE : 0;
 	// emode |= XGR_HICOLOR;
+	if (!XGR_FULL_SCREEN) {
+		const int startup_fullscreen = LoadStartupFullscreenOption();
+		if (startup_fullscreen != -1)
+			XGR_FULL_SCREEN = startup_fullscreen;
+	}
 
 	actintLowResFlag = 1;
 	if (XGR_Init(emode))
@@ -465,13 +507,6 @@ int xtInitApplication(void) {
 
 	// WORK	sWinVideo::Init();
 	//	::ShowCursor(0);
-
-	// zmod
-	if (!SkipIntro) {
-		//		showModal( "resource\\video\\intro\\logo1.avi", 512, 384, w, h );
-		//		showModal( "resource\\video\\intro\\logo2.avi", 512, 384, w, h );
-		//		showModal( "resource\\video\\intro\\intro.avi", 512, 380, w, h );
-	}
 
 	// WORK	sWinVideo::Done();
 
@@ -539,28 +574,9 @@ int xtInitApplication(void) {
 	//	  siObj -> SetName("resource\\iscreen\\bitmap\\kdlogo.bmp",0);
 	//	  siObj -> SetNext(RTO_MAIN_MENU_ID);
 
-	if (lang() == RUSSIAN) {
-		saObj->SetNumFiles(3);
-		// saObj -> SetName("resource\\video\\intro\\logo1.avi",0);
-		// saObj -> SetName("resource\\video\\intro\\logo2.avi",1);
-		// saObj -> SetName("resource\\video\\intro\\intro.avi",2);
-
-		//	saObj -> SetFlag(0,AVI_RTO_HICOLOR);
-		//	saObj -> SetFlag(1,AVI_RTO_HICOLOR);
-		//	saObj -> SetFlag(2,AVI_RTO_HICOLOR);
-	} else {
-		saObj->SetNumFiles(4);
-		saObj->SetName("resource/video/intro/logo0.avi", 0);
-		saObj->SetName("resource/video/intro/logo1.avi", 1);
-		saObj->SetName("resource/video/intro/logo2.avi", 2);
-		saObj->SetName("resource/video/intro/intro.avi", 3);
-		// znfo commented in zmod
-		//	saObj -> SetFlag(0,AVI_RTO_HICOLOR);
-		//	saObj -> SetFlag(1,AVI_RTO_HICOLOR);
-		//	saObj -> SetFlag(2,AVI_RTO_HICOLOR);
-		//	saObj -> SetFlag(3,AVI_RTO_HICOLOR);
-		// znfo
-	}
+	saObj->SetNumFiles(2);
+	saObj->SetName("resource/video/intro/logo2.avi", 0);
+	saObj->SetName("resource/video/intro/intro.avi", 1);
 	saObj->SetNext(RTO_MAIN_MENU_ID);
 
 	xtRegisterRuntimeObject(gqObj);
@@ -574,7 +590,7 @@ int xtInitApplication(void) {
 	xtRegisterRuntimeObject(lObj2);
 	xtRegisterRuntimeObject(lObj3);
 	xtRegisterRuntimeObject(siObj);
-	// xtRegisterRuntimeObject(saObj);
+	xtRegisterRuntimeObject(saObj);
 
 	if (RecorderMode)
 		XRec.Open(RecorderName, RecorderMode);
@@ -655,8 +671,10 @@ int xtInitApplication(void) {
 	char *res = setlocale(LC_NUMERIC, "POSIX");
 	std::cout << "Result:" << res << std::endl;
 #endif
-	if (SkipIntro)
-		return RTO_MAIN_MENU_ID;
+#ifdef SHOW_LOGOS
+	if (!SkipIntro)
+		return RTO_SHOW_AVI_ID;
+#endif
 	return RTO_MAIN_MENU_ID;
 }
 
@@ -2324,107 +2342,50 @@ void ShowImageRTO::Init(int id) {
 	_MEM_STATISTIC_("AFTER SHOW IMAGE RTO INIT -> ");
 }
 
+static void DrawStartupVideoFrame(void *avi) {
+	const int canvas_width = XGR_MAXX;
+	const int canvas_height = XGR_MAXY;
+	const int video_width = AVIwidth(avi);
+	const int video_height = AVIheight(avi);
+
+	int output_width = canvas_width;
+	int output_height = (video_height * canvas_width + video_width / 2) / video_width;
+	if (output_height > canvas_height) {
+		output_height = canvas_height;
+		output_width = (video_width * canvas_height + video_height / 2) / video_height;
+	}
+
+	const int x = (canvas_width - output_width) / 2;
+	const int y = (canvas_height - output_height) / 2;
+
+	XGR_Obj.fill(0);
+	XGR_Obj.clear_2d_surface();
+	XGR_Obj.fill(0, XGR_Obj.get_2d_rgba_render_buffer());
+	AVIPrepareFrame(avi);
+	AVIDrawFrame(
+		avi, x, y, XGR_MAXX, XGR_Obj.get_2d_rgba_render_buffer(), 1.0f, output_width, output_height
+	);
+}
+
 void ShowAviRTO::Init(int id) {
-#ifdef SHOW_LOGOS
-
-/*
-	int x,y,sx,sy;
-
-	XBuffer* XBuf = new XBuffer(1024);
-	char* avi_pal,*pal,*tpal;
-
-	if(!(Flags[curFile] & AVI_RTO_HICOLOR)){
-		pal = new char[768];
-		tpal = new char[768];
-		memset(tpal,0,768);
-	}
-
-	set_key_nadlers(ShowImageKeyPress,NULL);
-	XGR_MouseSetPressHandler(XGM_LEFT_BUTTON,ShowImageMousePress);
-	XGR_MouseSetPressHandler(XGM_RIGHT_BUTTON,ShowImageMousePress);
-
-	XBuf -> init();
-	*XBuf < iVideoPathDefault < fileNames[curFile];
-
-//	OLD XTOOL
-//	if(!AVIopen(XBuf -> address(),AVI_NOTIMER | AVI_NODRAW | AVI_NOPALETTE |
-AVI_NO_SOUND,0,&aviBuf)){ if(!AVIopen(XBuf -> address(),AVI_NOTIMER | AVI_NODRAW |
-AVI_NOPALETTE,0,&aviBuf)){ XBuf -> init(); *XBuf < iVideoPath < fileNames[curFile];
-//		OLD XTOOL
-//		if(!AVIopen(XBuf -> address(),AVI_NOTIMER | AVI_NODRAW | AVI_NOPALETTE |
-AVI_NO_SOUND,0,&aviBuf)){ if(!AVIopen(XBuf -> address(),AVI_NOTIMER | AVI_NODRAW |
-AVI_NOPALETTE,0,&aviBuf)){ aviBuf = NULL;
-		}
-	}
-
-	if(aviBuf){
-		if(!(Flags[curFile] & AVI_RTO_HICOLOR)){
-			if(XGR_Obj.flags & XGR_HICOLOR)
-				XGR_ReInit(800,600,emode);
-
-			XGR_Fill(0);
-			XGR_SetPal(tpal,0,255);
-			XGR_Flush(0,0,XGR_MAXX,XGR_MAXY);
-		}
-		else {
-			if(!(XGR_Obj.flags & XGR_HICOLOR)){
-				if(XGR_ReInit(800,600,emode | XGR_HICOLOR)){
-					XGR_ReInit(800,600,emode);
-					aviBuf = NULL;
-				}
-			}
-			else {
-//				OLD XTOOL
-//				XGR_Fill16RGB(0,0,0);
-				XGR_Fill16(0);
-				XGR_Flush(0,0,XGR_MAXX - 1,XGR_MAXY - 1);
-			}
-		}
-
-		if(aviBuf){
-			sx = AVIwidth(aviBuf);
-			sy = AVIheight(aviBuf);
-
-			x = (XGR_MAXX - sx) / 2;
-			y = (XGR_MAXY - sy) / 2;
-
-			if(!(Flags[curFile] & AVI_RTO_HICOLOR)){
-				avi_pal = (char*)AVIGetPalette(aviBuf);
-				memcpy(pal,avi_pal,768);
-
-				AVIplay(aviBuf,x,y);
-				AVIdraw(aviBuf);
-				AVIstop(aviBuf);
-				AVIclose(aviBuf);
-
-				PalEvidence(tpal,pal);
-
-				if(!AVIopen(XBuf -> address(),0,0,&aviBuf))
-					ErrH.Abort(AVInotFoundMSS);
-			}
-			else {
-				AVIstop(aviBuf);
-				AVIclose(aviBuf);
-//				OLD XTOOL
-//				if(!AVIopen(XBuf -> address(),AVI_HICOLOR,0,&aviBuf))
-				if(!AVIopen(XBuf -> address(),AVI_LOOPING,0,&aviBuf))
-					ErrH.Abort(AVInotFoundMSS);
-			}
-			AVIplay(aviBuf,x,y);
-		}
-	}
-	count = CLOCK();
-
+	XGR_Obj.set_is_scaled_renderer(false);
+	XGR_MouseHide();
+	aviBuf = NULL;
 	ShowImageMouseFlag = 0;
 	ShowImageKeyFlag = 0;
 
-	if(!(Flags[curFile] & AVI_RTO_HICOLOR)){
-		delete pal;
-		delete tpal;
+	set_key_handlers(&ShowImageKeyPress, NULL);
+	XGR_MouseSetPressHandler(XGM_LEFT_BUTTON, ShowImageMousePress);
+	XGR_MouseSetPressHandler(XGM_RIGHT_BUTTON, ShowImageMousePress);
+
+	if (AVIopen(fileNames[curFile], AVI_NODRAW | AVI_NOPALETTE, 0, &aviBuf)) {
+		AVIplay(aviBuf, 0, 0);
+		DrawStartupVideoFrame(aviBuf);
+	} else {
+		XGR_Obj.fill(0);
+		XGR_Obj.clear_2d_surface();
+		XGR_Obj.fill(0, XGR_Obj.get_2d_rgba_render_buffer());
 	}
-	delete XBuf;
-*/
-#endif
 	_MEM_STATISTIC_("AFTER SHOW IMAGE RTO INIT -> ");
 }
 
@@ -2459,30 +2420,16 @@ int ShowImageRTO::Quant(void) {
 }
 
 int ShowAviRTO::Quant(void) {
-#ifdef SHOW_LOGOS
-/*
-	int ret = 0;
-	if(aviBuf){
-		if(ShowImageKeyFlag || ShowImageMouseFlag){
-			ret = 1;
-		}
-//		OLD XTOOL
-//		if(AVIactive(aviBuf)){
-			count= CLOCK();
-//		}
-//		else {
-//			if((count + 100) < CLOCK())
-//				ret = 1;
-//		}
+	if (aviBuf && !ShowImageKeyFlag && !ShowImageMouseFlag) {
+		DrawStartupVideoFrame(aviBuf);
 
-		if(!ret) return 0;
+		if (!AVIisFinished(aviBuf))
+			return 0;
 	}
-*/
-#endif
+
 	curFile++;
-	if (curFile >= numFiles) {
+	if (curFile >= numFiles)
 		return NextID;
-	}
 
 	return ID;
 }
@@ -2502,27 +2449,15 @@ void ShowImageRTO::Finit(void) {
 }
 
 void ShowAviRTO::Finit(void) {
-#ifdef SHOW_LOGOS
-/*
-	char* pal;
-
-	if(aviBuf){
+	if (aviBuf) {
 		AVIstop(aviBuf);
 		AVIclose(aviBuf);
-
-		if(XGR_Obj.flags & XGR_HICOLOR && curFile >= numFiles) XGR_ReInit(800,600,emode);
-
-		if(!(Flags[curFile - 1] & AVI_RTO_HICOLOR)){
-			pal = new char[768];
-			i_slake_pal((unsigned char*)pal,32);
-			delete pal;
-		}
+		aviBuf = NULL;
 	}
-	else {
-		if(XGR_Obj.flags & XGR_HICOLOR && curFile >= numFiles) XGR_ReInit(800,600,emode);
-	}
-*/
-#endif
+	XGR_Obj.fill(0);
+	XGR_Obj.clear_2d_surface();
+	XGR_Obj.fill(0, XGR_Obj.get_2d_rgba_render_buffer());
+	XGR_Obj.set_is_scaled_renderer(false);
 	_MEM_STATISTIC_("AFTER SHOW IMAGE RTO 4 FINIT -> ");
 }
 
@@ -2770,9 +2705,9 @@ ShowImageRTO::ShowImageRTO(void) {
 }
 
 ShowAviRTO::ShowAviRTO(void) {
-	int i;
 	ID = RTO_SHOW_AVI_ID;
 	Timer = RTO_IMAGE_TIMER;
+	aviBuf = NULL;
 }
 
 void SetupPath(void) {


### PR DESCRIPTION
## Summary

Restore the original startup movies on SDL/Unix builds using the existing FFmpeg and Clunk backends.

The startup sequence is intentionally limited to:

1. `resource/video/intro/logo2.avi`
2. `resource/video/intro/intro.avi`
3. main menu

## What changed

- reconnect `ShowAviRTO` to the startup runtime flow;
- add `-skipintro` support;
- decode Indeo 3 `yuv410p` frames through `libswscale`;
- preserve the existing untimed/frame-per-call behavior of interface AVI animations;
- use PTS-based timing and EOF detection for startup movies;
- play embedded PCM S16LE audio through Clunk;
- scale video to the active output without changing aspect ratio, using black bars where needed;
- allow keyboard or mouse input to skip the current movie;
- hide the cursor during playback and let normal menu initialization restore its input handlers;
- continue to the menu safely if either AVI is absent or cannot be decoded;
- apply the existing saved fullscreen value before video initialization without changing the `options.dat` format;
- discover and link `libswscale` through the existing FFmpeg CMake module.

## Why the AVI layer needed changes

The disabled legacy startup implementation depended on the removed Windows video backend. The cross-platform AVI layer could only draw `pal8` and `yuv444p`, advanced one frame per game tick, had no reliable EOF signal, and ignored embedded audio. The shipped intro files are 15 FPS Indeo 3 videos using `yuv410p` with mono PCM S16LE audio.

## Compatibility

Interface AVI elements still use `AVI_NOTIMER`, so their existing frame-per-call animation cadence is unchanged. Timed playback, audio loading, and EOF handling are used by the startup movies.

The complete settings file is still loaded normally by the menu. Startup only reads the validated fixed tail of the existing `options.dat` to know whether the initial SDL window must be fullscreen; nothing is added to or rewritten in the save format.

Steam packaging/build configuration is deliberately not changed in this PR.

## Validation

- `clang-format 22 --dry-run --Werror` passes for every changed C/C++ file.
- Clean GCC 16 Release build succeeds for all 132 targets.
- Clean Clang 22 ASan/UBSan build succeeds for all 132 targets.
- Full `logo2 -> intro -> menu` playback completes without sanitizer runtime errors in the new video/audio path.
- Both saved fullscreen values (`0` and `1`) are applied before `ShowAviRTO` starts.
- `-skipintro` starts directly in `MainMenuRTO` without entering `ShowAviRTO`.
- Missing startup AVI files safely fall through to a functional menu.
- Runtime inspection confirms:
  - the cursor is hidden during both movies;
  - the active menu restores `iMS_LeftPress` rather than retaining the intro skip handler.
