### PR TITLE
Do not abort on fullscreen synchronization timeout

### DIFF
--- a/lib/xgraph/xgraph.cpp
+++ b/lib/xgraph/xgraph.cpp
@@ -335,8 +335,14 @@ void XGR_Screen::destroy_surfaces() {
 
 void XGR_Screen::set_fullscreen(bool fullscreen) {
 	if (fullscreen != XGR_FULL_SCREEN) {
-		if (!SDL_SetWindowFullscreen(sdlWindow, fullscreen) || !SDL_SyncWindow(sdlWindow))
+		if (!SDL_SetWindowFullscreen(sdlWindow, fullscreen))
 			ErrH.Abort(SDL_GetError(), XERR_USER, 0);
+		if (!SDL_SyncWindow(sdlWindow)) {
+			const char *warning =
+				"Warning: fullscreen transition did not complete before SDL_SyncWindow timed out";
+			std::cerr << warning << std::endl;
+			ErrH.Log(warning);
+		}
 		if (!fullscreen) {
 			if (!SDL_SetWindowSize(sdlWindow, XGR_MAXX, XGR_MAXY))
 				ErrH.Abort(SDL_GetError(), XERR_USER, 0);


### PR DESCRIPTION
## Problem

Switching fullscreen mode can terminate the game on asynchronous window systems, notably Steam Deck/Gamescope.

`SDL_SetWindowFullscreen()` and `SDL_SyncWindow()` were combined into one fatal condition. These functions report different situations:

- `SDL_SetWindowFullscreen()` returns false when the fullscreen request fails.
- `SDL_SyncWindow()` returns false when waiting for an accepted asynchronous window transition times out.

A compositor can therefore take longer than SDL's synchronization limit while the fullscreen request remains valid. The game interpreted that timeout as a fatal SDL error and could abort with an empty error message.

## Fix

- Keep an actual `SDL_SetWindowFullscreen()` failure fatal.
- Treat an `SDL_SyncWindow()` timeout as non-fatal.
- Write a warning to stderr and `logfile.txt`.
- Continue the existing window sizing, positioning, and fullscreen-state update.

This preserves real error handling while preventing a slow asynchronous transition from crashing the game. No Steam Input or closed Steam integration code is involved.

## Validation

- Complete local build succeeds.
- All 8 CTest targets pass.
- `clang-format --dry-run --Werror lib/xgraph/xgraph.cpp` passes.
- `git diff --check` passes.
